### PR TITLE
build: add back @commitlint/config-conventional to resolve publishing issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,15 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
+    "@commitlint/config-conventional": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-13.2.0.tgz",
+      "integrity": "sha512-7u7DdOiF+3qSdDlbQGfpvCH8DCQdLFvnI2+VucYmmV7E92iD6t9PBj+UjIoSQCaMAzYp27Vkall78AkcXBh6Xw==",
+      "dev": true,
+      "requires": {
+        "conventional-changelog-conventionalcommits": "^4.3.1"
+      }
+    },
     "@cospired/i18n-iso-languages": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@cospired/i18n-iso-languages/-/i18n-iso-languages-2.2.0.tgz",
@@ -2379,6 +2388,17 @@
       "dev": true,
       "requires": {
         "compare-func": "^2.0.0",
+        "q": "^1.5.1"
+      }
+    },
+    "conventional-changelog-conventionalcommits": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.1.tgz",
+      "integrity": "sha512-lzWJpPZhbM1R0PIzkwzGBCnAkH5RKJzJfFQZcl/D+2lsJxAwGnDKBqn/F4C1RD31GJNn8NuKWQzAZDAVXPp2Mw==",
+      "dev": true,
+      "requires": {
+        "compare-func": "^2.0.0",
+        "lodash": "^4.17.15",
         "q": "^1.5.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "changed": "lerna changed"
   },
   "devDependencies": {
+    "@commitlint/config-conventional": "13.2.0",
     "@edx/frontend-platform": "1.9.6",
     "@edx/paragon": "14.5.0",
     "husky": "6.0.0",


### PR DESCRIPTION
**Description**

Since we removed the local commitlint packages, we unintentionally removed a transitive dependency that Lerna depended on (i.e., `conventional-changelog-conventionalcommits`) via `@commitlint/config-conventional` in [this PR](https://github.com/edx/frontend-enterprise/pull/176). This caused Lerna to error when attempting to create a new release of package(s).

The lerna.json configuration file specifies a `changelogPreset` of `conventionalcommits` (i.e., `conventional-changelog-conventionalcommits`), but since that preset was removed when `@commitlint/config-conventional` was uninstalled, Lerna couldn't find the preset as configured.

By re-installing `@commitlint/config-conventional`, Lerna will have the necessary transitive dependency to do its thing properly.

**Merge checklist:**
- [x] Ensure your commit message follows the semantic-release conventional commit message format
- [x] Once CI is passing, verify the package versions that Lerna will increment to in the Github Action CI workflow logs.
    - *Note*: This may be found in the "Preview Updated Versions (dry run)" step in the Github Action CI workflow logs.

**Post merge:**
- [x] Verify Lerna created a release commit (e.g., ``chore(release): publish``) that incremented versions in relevant package.json and CHANGELOG files, and created [Git tags](https://github.com/edx/frontend-enterprise/tags) for those versions.
- [x] Run the ``Publish from package.json`` Github Action [workflow](https://github.com/edx/frontend-enterprise/actions/workflows/publish-from-package.yml) to publish these new package versions to NPM.
    - This may be triggered by clicking the "Run workflow" option for the ``master`` branch.
- [ ] Verify the new package versions were published to NPM (i.e., ``npm view <package_name> versions --json``).
    - *Note*: There may be a slight delay between when the workflow finished and when NPM reports the package version as being published. If it doesn't appear right away in the above command, try again in a few minutes.
