### PR TITLE
fix: Use media query to resize for mobile in SearchFilters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ lerna-debug.log
 .DS_Store
 coverage/
 dist/
+packages/*/package-lock.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -2368,50 +2368,35 @@
       }
     },
     "node_modules/@edx/paragon": {
-      "version": "14.5.0",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-14.5.0.tgz",
-      "integrity": "sha512-IQ+tjbhpzTBW4rw/1RFBOGKIaPiReXGLLKgBHrvERlnshpwxauiU7odA2hM9B33EGE5yiKRVcvstSdhy76UaFg==",
+      "version": "19.25.1",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-19.25.1.tgz",
+      "integrity": "sha512-R04Fm3FtvYI2v9llV/a7GHtMEtTVzyllSnQA3snjrVdGnfpgidQLUw7F3b9uVvpWHxpttqX4uhsQzZrzmzFK6A==",
       "dev": true,
       "dependencies": {
-        "@fortawesome/fontawesome-svg-core": "^1.2.30",
-        "@fortawesome/free-solid-svg-icons": "^5.14.0",
-        "@fortawesome/react-fontawesome": "^0.1.11",
-        "@popperjs/core": "^2.6.0",
-        "airbnb-prop-types": "^2.12.0",
-        "bootstrap": "4.6.0",
-        "classnames": "^2.2.6",
+        "@fortawesome/fontawesome-svg-core": "^1.2.36",
+        "@fortawesome/react-fontawesome": "^0.1.18",
+        "@popperjs/core": "^2.11.4",
+        "airbnb-prop-types": "^2.16.0",
+        "bootstrap": "^4.6.1",
+        "classnames": "^2.3.1",
         "email-prop-type": "^3.0.0",
         "font-awesome": "^4.7.0",
+        "lodash.uniqby": "^4.7.0",
         "mailto-link": "^1.0.0",
-        "prop-types": "^15.7.2",
-        "react-bootstrap": "^1.3.0",
-        "react-focus-on": "^3.5.0",
-        "react-popper": "^2.2.4",
+        "prop-types": "^15.8.1",
+        "react-bootstrap": "^1.6.4",
+        "react-focus-on": "^3.5.4",
+        "react-popper": "^2.2.5",
         "react-proptype-conditional-require": "^1.0.4",
-        "react-responsive": "^6.1.1",
-        "react-table": "^7.6.1",
-        "react-transition-group": "^4.0.0",
-        "sanitize-html": "^1.20.0",
+        "react-responsive": "^8.2.0",
+        "react-table": "^7.7.0",
+        "react-transition-group": "^4.4.2",
         "tabbable": "^4.0.0",
-        "uncontrollable": "7.2.1"
+        "uncontrollable": "^7.2.1"
       },
       "peerDependencies": {
-        "prop-types": "^15.7.2",
-        "react": "^16.8.6",
-        "react-dom": "^16.8.6"
-      }
-    },
-    "node_modules/@edx/paragon/node_modules/@fortawesome/free-solid-svg-icons": {
-      "version": "5.15.4",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.4.tgz",
-      "integrity": "sha512-JLmQfz6tdtwxoihXLg6lT78BorrFyCf59SAwBM6qV/0zXyVeDygJVb3fk+j5Qat+Yvcxp1buLTY5iDh1ZSAQ8w==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "^0.2.36"
-      },
-      "engines": {
-        "node": ">=6"
+        "react": "^16.8.6 || ^17.0.0",
+        "react-dom": "^16.8.6 || ^17.0.0"
       }
     },
     "node_modules/@edx/paragon/node_modules/@fortawesome/react-fontawesome": {
@@ -9049,9 +9034,9 @@
       "dev": true
     },
     "node_modules/bootstrap": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.0.tgz",
-      "integrity": "sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.1.tgz",
+      "integrity": "sha512-0dj+VgI9Ecom+rvvpNZ4MUZJz8dcX7WCX+eTID9+/8HgOkv3dsRzi8BGeZJCQU6flWQVYxwTQnEZFrmJSEO7og==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -10625,7 +10610,7 @@
     "node_modules/css-mediaquery": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
-      "integrity": "sha1-aiw3NEkoYYYxxUvTPO3TAdoYvqA=",
+      "integrity": "sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q==",
       "dev": true
     },
     "node_modules/css-select": {
@@ -19980,6 +19965,12 @@
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
     },
+    "node_modules/lodash.uniqby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+      "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
+      "dev": true
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -22092,12 +22083,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/parse-srcset": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
-      "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE=",
-      "dev": true
-    },
     "node_modules/parse-url": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-6.0.0.tgz",
@@ -24072,20 +24057,21 @@
       "dev": true
     },
     "node_modules/react-responsive": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-6.1.2.tgz",
-      "integrity": "sha512-AXentVC/kN3KED9zhzJv2pu4vZ0i6cSHdTtbCScVV1MT6F5KXaG2qs5D7WLmhdaOvmiMX8UfmS4ZSO+WPwDt4g==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-8.2.0.tgz",
+      "integrity": "sha512-iagCqVrw4QSjhxKp3I/YK6+ODkWY6G+YPElvdYKiUUbywwh9Ds0M7r26Fj2/7dWFFbOpcGnJE6uE7aMck8j5Qg==",
       "dev": true,
       "dependencies": {
         "hyphenate-style-name": "^1.0.0",
         "matchmediaquery": "^0.3.0",
-        "prop-types": "^15.6.1"
+        "prop-types": "^15.6.1",
+        "shallow-equal": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.10"
       },
       "peerDependencies": {
-        "react": "^16.3.0"
+        "react": ">=16.8.0"
       }
     },
     "node_modules/react-router": {
@@ -25351,86 +25337,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/sanitize-html": {
-      "version": "1.27.5",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.27.5.tgz",
-      "integrity": "sha512-M4M5iXDAUEcZKLXkmk90zSYWEtk5NH3JmojQxKxV371fnMh+x9t1rqdmXaGoyEHw3z/X/8vnFhKjGL5xFGOJ3A==",
-      "dev": true,
-      "dependencies": {
-        "htmlparser2": "^4.1.0",
-        "lodash": "^4.17.15",
-        "parse-srcset": "^1.0.2",
-        "postcss": "^7.0.27"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/domhandler": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
-      "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
-      "dev": true,
-      "dependencies": {
-        "domelementtype": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/htmlparser2": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
-      "integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
-      "dev": true,
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^3.0.0",
-        "domutils": "^2.0.0",
-        "entities": "^2.0.0"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/picocolors": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-      "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-      "dev": true
-    },
-    "node_modules/sanitize-html/node_modules/postcss": {
-      "version": "7.0.39",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-      "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-      "dev": true,
-      "dependencies": {
-        "picocolors": "^0.2.1",
-        "source-map": "^0.6.1"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      }
-    },
-    "node_modules/sanitize-html/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/sass": {
       "version": "1.49.9",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.49.9.tgz",
@@ -25806,6 +25712,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/shallow-equal": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
+      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==",
+      "dev": true
     },
     "node_modules/shebang-command": {
       "version": "1.2.0",
@@ -29541,10 +29453,10 @@
     },
     "packages/catalog-search": {
       "name": "@edx/frontend-enterprise-catalog-search",
-      "version": "2.9.0",
+      "version": "3.0.2",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@edx/frontend-enterprise-utils": "^1.3.0",
+        "@edx/frontend-enterprise-utils": "^2.0.1",
         "classnames": "2.2.5",
         "lodash.debounce": "4.0.8",
         "prop-types": "15.7.2"
@@ -29552,8 +29464,9 @@
       "devDependencies": {
         "@edx/browserslist-config": "1.0.0",
         "@edx/frontend-build": "9.1.4",
+        "@edx/frontend-enterprise-catalog-search": "^3.0.2",
         "@edx/frontend-platform": "1.15.6",
-        "@edx/paragon": "14.5.0",
+        "@edx/paragon": "^19.25.1",
         "@fortawesome/free-solid-svg-icons": "5.8.1",
         "@fortawesome/react-fontawesome": "0.1.4",
         "@testing-library/jest-dom": "5.11.6",
@@ -29579,16 +29492,18 @@
     },
     "packages/logistration": {
       "name": "@edx/frontend-enterprise-logistration",
-      "version": "1.1.2",
+      "version": "2.0.1",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@edx/frontend-enterprise-utils": "^1.3.0",
+        "@edx/frontend-enterprise-utils": "^2.0.1",
         "prop-types": "15.7.2"
       },
       "devDependencies": {
         "@edx/browserslist-config": "1.0.0",
         "@edx/frontend-build": "9.1.4",
+        "@edx/frontend-enterprise-catalog-search": "^3.0.2",
         "@edx/frontend-platform": "1.15.6",
+        "@edx/paragon": "^19.25.1",
         "@testing-library/jest-dom": "5.11.6",
         "@testing-library/react": "11.2.6",
         "react": "16.12.0",
@@ -29659,7 +29574,7 @@
     },
     "packages/utils": {
       "name": "@edx/frontend-enterprise-utils",
-      "version": "1.3.0",
+      "version": "2.0.1",
       "license": "AGPL-3.0",
       "dependencies": {
         "@testing-library/react": "11.2.6",
@@ -29668,7 +29583,9 @@
       "devDependencies": {
         "@edx/browserslist-config": "1.0.0",
         "@edx/frontend-build": "9.1.4",
+        "@edx/frontend-enterprise-catalog-search": "^3.0.2",
         "@edx/frontend-platform": "1.15.6",
+        "@edx/paragon": "^19.25.1",
         "react": "16.14.0",
         "react-dom": "16.14.0",
         "react-router-dom": "5.2.0",
@@ -31345,9 +31262,10 @@
       "requires": {
         "@edx/browserslist-config": "1.0.0",
         "@edx/frontend-build": "9.1.4",
-        "@edx/frontend-enterprise-utils": "^1.3.0",
+        "@edx/frontend-enterprise-catalog-search": "*",
+        "@edx/frontend-enterprise-utils": "^2.0.1",
         "@edx/frontend-platform": "1.15.6",
-        "@edx/paragon": "14.5.0",
+        "@edx/paragon": "19.25.1",
         "@fortawesome/free-solid-svg-icons": "5.8.1",
         "@fortawesome/react-fontawesome": "0.1.4",
         "@testing-library/jest-dom": "5.11.6",
@@ -31369,8 +31287,10 @@
       "requires": {
         "@edx/browserslist-config": "1.0.0",
         "@edx/frontend-build": "9.1.4",
-        "@edx/frontend-enterprise-utils": "^1.3.0",
+        "@edx/frontend-enterprise-catalog-search": "*",
+        "@edx/frontend-enterprise-utils": "^2.0.1",
         "@edx/frontend-platform": "1.15.6",
+        "@edx/paragon": "19.25.1",
         "@testing-library/jest-dom": "5.11.6",
         "@testing-library/react": "11.2.6",
         "prop-types": "15.7.2",
@@ -31432,7 +31352,9 @@
       "requires": {
         "@edx/browserslist-config": "1.0.0",
         "@edx/frontend-build": "9.1.4",
+        "@edx/frontend-enterprise-catalog-search": "*",
         "@edx/frontend-platform": "1.15.6",
+        "@edx/paragon": "19.25.1",
         "@testing-library/react": "11.2.6",
         "history": "4.10.1",
         "react": "16.14.0",
@@ -31487,43 +31409,33 @@
       }
     },
     "@edx/paragon": {
-      "version": "14.5.0",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-14.5.0.tgz",
-      "integrity": "sha512-IQ+tjbhpzTBW4rw/1RFBOGKIaPiReXGLLKgBHrvERlnshpwxauiU7odA2hM9B33EGE5yiKRVcvstSdhy76UaFg==",
+      "version": "19.25.1",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-19.25.1.tgz",
+      "integrity": "sha512-R04Fm3FtvYI2v9llV/a7GHtMEtTVzyllSnQA3snjrVdGnfpgidQLUw7F3b9uVvpWHxpttqX4uhsQzZrzmzFK6A==",
       "dev": true,
       "requires": {
-        "@fortawesome/fontawesome-svg-core": "^1.2.30",
-        "@fortawesome/free-solid-svg-icons": "^5.14.0",
-        "@fortawesome/react-fontawesome": "^0.1.11",
-        "@popperjs/core": "^2.6.0",
-        "airbnb-prop-types": "^2.12.0",
-        "bootstrap": "4.6.0",
-        "classnames": "^2.2.6",
+        "@fortawesome/fontawesome-svg-core": "^1.2.36",
+        "@fortawesome/react-fontawesome": "^0.1.18",
+        "@popperjs/core": "^2.11.4",
+        "airbnb-prop-types": "^2.16.0",
+        "bootstrap": "^4.6.1",
+        "classnames": "^2.3.1",
         "email-prop-type": "^3.0.0",
         "font-awesome": "^4.7.0",
+        "lodash.uniqby": "^4.7.0",
         "mailto-link": "^1.0.0",
-        "prop-types": "^15.7.2",
-        "react-bootstrap": "^1.3.0",
-        "react-focus-on": "^3.5.0",
-        "react-popper": "^2.2.4",
+        "prop-types": "^15.8.1",
+        "react-bootstrap": "^1.6.4",
+        "react-focus-on": "^3.5.4",
+        "react-popper": "^2.2.5",
         "react-proptype-conditional-require": "^1.0.4",
-        "react-responsive": "^6.1.1",
-        "react-table": "^7.6.1",
-        "react-transition-group": "^4.0.0",
-        "sanitize-html": "^1.20.0",
+        "react-responsive": "^8.2.0",
+        "react-table": "^7.7.0",
+        "react-transition-group": "^4.4.2",
         "tabbable": "^4.0.0",
-        "uncontrollable": "7.2.1"
+        "uncontrollable": "^7.2.1"
       },
       "dependencies": {
-        "@fortawesome/free-solid-svg-icons": {
-          "version": "5.15.4",
-          "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.4.tgz",
-          "integrity": "sha512-JLmQfz6tdtwxoihXLg6lT78BorrFyCf59SAwBM6qV/0zXyVeDygJVb3fk+j5Qat+Yvcxp1buLTY5iDh1ZSAQ8w==",
-          "dev": true,
-          "requires": {
-            "@fortawesome/fontawesome-common-types": "^0.2.36"
-          }
-        },
         "@fortawesome/react-fontawesome": {
           "version": "0.1.18",
           "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.18.tgz",
@@ -36726,9 +36638,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.0.tgz",
-      "integrity": "sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.1.tgz",
+      "integrity": "sha512-0dj+VgI9Ecom+rvvpNZ4MUZJz8dcX7WCX+eTID9+/8HgOkv3dsRzi8BGeZJCQU6flWQVYxwTQnEZFrmJSEO7og==",
       "dev": true,
       "requires": {}
     },
@@ -37961,7 +37873,7 @@
     "css-mediaquery": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
-      "integrity": "sha1-aiw3NEkoYYYxxUvTPO3TAdoYvqA=",
+      "integrity": "sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q==",
       "dev": true
     },
     "css-select": {
@@ -45161,6 +45073,12 @@
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
     },
+    "lodash.uniqby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+      "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
+      "dev": true
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -46768,12 +46686,6 @@
         }
       }
     },
-    "parse-srcset": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
-      "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE=",
-      "dev": true
-    },
     "parse-url": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-6.0.0.tgz",
@@ -48195,14 +48107,15 @@
       }
     },
     "react-responsive": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-6.1.2.tgz",
-      "integrity": "sha512-AXentVC/kN3KED9zhzJv2pu4vZ0i6cSHdTtbCScVV1MT6F5KXaG2qs5D7WLmhdaOvmiMX8UfmS4ZSO+WPwDt4g==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-8.2.0.tgz",
+      "integrity": "sha512-iagCqVrw4QSjhxKp3I/YK6+ODkWY6G+YPElvdYKiUUbywwh9Ds0M7r26Fj2/7dWFFbOpcGnJE6uE7aMck8j5Qg==",
       "dev": true,
       "requires": {
         "hyphenate-style-name": "^1.0.0",
         "matchmediaquery": "^0.3.0",
-        "prop-types": "^15.6.1"
+        "prop-types": "^15.6.1",
+        "shallow-equal": "^1.1.0"
       }
     },
     "react-router": {
@@ -49215,69 +49128,6 @@
         }
       }
     },
-    "sanitize-html": {
-      "version": "1.27.5",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.27.5.tgz",
-      "integrity": "sha512-M4M5iXDAUEcZKLXkmk90zSYWEtk5NH3JmojQxKxV371fnMh+x9t1rqdmXaGoyEHw3z/X/8vnFhKjGL5xFGOJ3A==",
-      "dev": true,
-      "requires": {
-        "htmlparser2": "^4.1.0",
-        "lodash": "^4.17.15",
-        "parse-srcset": "^1.0.2",
-        "postcss": "^7.0.27"
-      },
-      "dependencies": {
-        "domhandler": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
-          "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
-          "dev": true,
-          "requires": {
-            "domelementtype": "^2.0.1"
-          }
-        },
-        "entities": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-          "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-          "dev": true
-        },
-        "htmlparser2": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
-          "integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
-          "dev": true,
-          "requires": {
-            "domelementtype": "^2.0.1",
-            "domhandler": "^3.0.0",
-            "domutils": "^2.0.0",
-            "entities": "^2.0.0"
-          }
-        },
-        "picocolors": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-          "integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-          "dev": true
-        },
-        "postcss": {
-          "version": "7.0.39",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-          "integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-          "dev": true,
-          "requires": {
-            "picocolors": "^0.2.1",
-            "source-map": "^0.6.1"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
-      }
-    },
     "sass": {
       "version": "1.49.9",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.49.9.tgz",
@@ -49575,6 +49425,12 @@
       "requires": {
         "kind-of": "^6.0.2"
       }
+    },
+    "shallow-equal": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
+      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==",
+      "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/packages/catalog-search/package.json
+++ b/packages/catalog-search/package.json
@@ -45,7 +45,7 @@
     "@edx/browserslist-config": "1.0.0",
     "@edx/frontend-build": "9.1.4",
     "@edx/frontend-platform": "1.15.6",
-    "@edx/paragon": "14.5.0",
+    "@edx/paragon": "^19.25.1",
     "@fortawesome/free-solid-svg-icons": "5.8.1",
     "@fortawesome/react-fontawesome": "0.1.4",
     "@testing-library/jest-dom": "5.11.6",

--- a/packages/catalog-search/src/SearchFilters.jsx
+++ b/packages/catalog-search/src/SearchFilters.jsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useContext } from 'react';
 import PropTypes from 'prop-types';
-import { breakpoints, useWindowSize } from '@edx/paragon';
+import { breakpoints, MediaQuery } from '@edx/paragon';
 
 import FacetListRefinement from './FacetListRefinement';
 import FacetListBase from './FacetListBase';
@@ -18,12 +18,7 @@ import LearningTypeRadioFacet from './LearningTypeRadioFacet';
 export const FREE_ALL_TITLE = 'Free / All';
 
 const SearchFilters = ({ variant }) => {
-  const size = useWindowSize();
   const { refinements, searchFacetFilters } = useContext(SearchContext);
-  const showMobileMenu = useMemo(
-    () => size.width < breakpoints.large.maxWidth,
-    [JSON.stringify(size)],
-  );
   const freeAllItems = useMemo(() => [
     {
       label: 'Free to me',
@@ -85,18 +80,19 @@ const SearchFilters = ({ variant }) => {
 
   return (
     <>
-      {showMobileMenu ? (
+      <MediaQuery maxWidth={breakpoints.large.maxWidth}>
         <MobileFilterMenu className="mb-3">
           {searchFacets}
         </MobileFilterMenu>
-      ) : (
+      </MediaQuery>
+      <MediaQuery minWidth={breakpoints.extraLarge.minWidth}>
         <>
           <div className="d-flex">
             {searchFacets}
           </div>
           <CurrentRefinements variant={variant} />
         </>
-      )}
+      </MediaQuery>
     </>
   );
 };

--- a/packages/catalog-search/src/tests/SearchFilters.test.jsx
+++ b/packages/catalog-search/src/tests/SearchFilters.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
+import { breakpoints, ResponsiveContext } from '@edx/paragon';
 import { SEARCH_FACET_FILTERS } from '../data/constants';
 
 import { renderWithSearchContext } from './utils';
@@ -10,7 +11,11 @@ import SearchFilters from '../SearchFilters';
 
 describe('<SearchFilters />', () => {
   test('renders with a label', () => {
-    renderWithSearchContext(<SearchFilters />);
+    renderWithSearchContext(
+      <ResponsiveContext.Provider value={{ width: breakpoints.large.maxWidth }}>
+        <SearchFilters />
+      </ResponsiveContext.Provider>,
+    );
     SEARCH_FACET_FILTERS.forEach((filter) => {
       expect(screen.getByText(filter.title)).toBeInTheDocument();
     });

--- a/packages/logistration/package.json
+++ b/packages/logistration/package.json
@@ -43,7 +43,9 @@
   "devDependencies": {
     "@edx/browserslist-config": "1.0.0",
     "@edx/frontend-build": "9.1.4",
+    "@edx/frontend-enterprise-catalog-search": "^3.0.2",
     "@edx/frontend-platform": "1.15.6",
+    "@edx/paragon": "^19.25.1",
     "@testing-library/jest-dom": "5.11.6",
     "@testing-library/react": "11.2.6",
     "react": "16.12.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -42,7 +42,9 @@
   "devDependencies": {
     "@edx/browserslist-config": "1.0.0",
     "@edx/frontend-build": "9.1.4",
+    "@edx/frontend-enterprise-catalog-search": "^3.0.2",
     "@edx/frontend-platform": "1.15.6",
+    "@edx/paragon": "^19.25.1",
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "react-router-dom": "5.2.0",


### PR DESCRIPTION
ENT-5800.  Also installs react-responsive as a peer dependency.

Something about `useWindowSize()` from paragon isn't working quite right with the edx.org theme, so our original solution for https://2u-internal.atlassian.net/browse/ENT-5800 isn't working.  From Adam:
> I think the issue is that useWindowSize is including the extra width of the overflow facets in the total width. for example, at a window width of 1190px but useWindowSize says it's at 1249px, which is still above the breakpoint.

Note that there's still a little overrun from 1200px < screen width < ~1350px, but it's far better than before and I don't want to squish into the mobile view for reasonably-sized desktop browser windows by switching to the XL breakpoint.

![media-query](https://user-images.githubusercontent.com/2307986/171694761-ac344ae2-cc4e-4424-baa3-89b28eb1f458.gif)

**Merge checklist:**
- [x] Evaluate how your changes will impact existing consumers (e.g., `frontend-app-learner-portal-enterprise`, `frontend-app-admin-portal`, and `frontend-app-enterprise-public-catalog`). Will consumers safely be able to upgrade to this change without any breaking changes?
- [x] Ensure your commit message follows the semantic-release conventional commit message format. If your changes include a breaking change, ensure your commit message is explicitly marked as a `BREAKING CHANGE` so the NPM package is released as such.
- [x] Once CI is passing, verify the package versions that Lerna will increment to in the Github Action CI workflow logs.
    - *Note*: This may be found in the "Preview Updated Versions (dry run)" step in the Github Action CI workflow logs.

**Post merge:**
- [ ] Verify Lerna created a release commit (e.g., ``chore(release): publish``) that incremented versions in relevant package.json and CHANGELOG files, and created [Git tags](https://github.com/edx/frontend-enterprise/tags) for those versions.
- [ ] Run the ``Publish from package.json`` Github Action [workflow](https://github.com/edx/frontend-enterprise/actions/workflows/publish-from-package.yml) to publish these new package versions to NPM.
    - This may be triggered by clicking the "Run workflow" option for the ``master`` branch.
- [ ] Verify the new package versions were published to NPM (i.e., ``npm view <package_name> versions --json``).
    - *Note*: There may be a slight delay between when the workflow finished and when NPM reports the package version as being published. If it doesn't appear right away in the above command, try again in a few minutes.
