### PR TITLE
fix: only apply bg-brand-primary to SearchHeader if variant=inverse

### DIFF
--- a/packages/catalog-search/src/SearchHeader.jsx
+++ b/packages/catalog-search/src/SearchHeader.jsx
@@ -9,6 +9,7 @@ import { STYLE_VARIANTS } from './data/constants';
 
 import { SearchContext } from './SearchContext';
 
+export const searchHeaderTestId = 'search-header';
 export const searchBoxColTestId = 'search-box-col';
 export const filtersColTestId = 'filters-col';
 
@@ -33,7 +34,10 @@ const SearchHeader = ({
   }
 
   return (
-    <div className="bg-brand-primary">
+    <div
+      data-testid={searchHeaderTestId}
+      className={classNames({ 'bg-brand-primary': variant === STYLE_VARIANTS.inverse })}
+    >
       <Container size={containerSize}>
         <Row className="pt-4 pb-3">
           <Col

--- a/packages/catalog-search/src/tests/SearchHeader.test.jsx
+++ b/packages/catalog-search/src/tests/SearchHeader.test.jsx
@@ -2,7 +2,9 @@ import React from 'react';
 import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
-import SearchHeader, { filtersColTestId, searchBoxColTestId } from '../SearchHeader';
+import SearchHeader, {
+  filtersColTestId, searchBoxColTestId, searchHeaderTestId,
+} from '../SearchHeader';
 import { STYLE_VARIANTS } from '../data/constants';
 
 import { renderWithSearchContext } from './utils';
@@ -26,10 +28,12 @@ describe('SearchHeader', () => {
   test('has the inverse variant by default -- search box', () => {
     renderWithSearchContext(<SearchHeader enterpriseConfig={enterpriseConfig} />);
     expect(screen.getByTestId(searchBoxColTestId).className).not.toContain('fe__searchbox-col--default');
+    expect(screen.getByTestId(searchHeaderTestId).className).toContain('bg-brand-primary');
   });
-  test('adds class names for default variant -- search box', () => {
+  test('has class names for default variant -- search box', () => {
     renderWithSearchContext(<SearchHeader variant={STYLE_VARIANTS.default} enterpriseConfig={enterpriseConfig} />);
     expect(screen.getByTestId(searchBoxColTestId).className).toContain('fe__searchbox-col--default');
+    expect(screen.getByTestId(searchHeaderTestId).className).not.toContain('bg-brand-primary');
   });
   test('has the inverse variant by default -- filters', () => {
     renderWithSearchContext(<SearchHeader enterpriseConfig={enterpriseConfig} />);


### PR DESCRIPTION
# Description

Fixes the issue where there is incorrectly a background color on the `SearchHeader` component used across 3 MFEs. 

## Screenshots

### Before (Bulk Enrollment)

<img width="1375" alt="image" src="https://user-images.githubusercontent.com/2828721/205927672-13ae20cb-148d-4495-8527-464c8754eadf.png">

### After (Bulk Enrollment)

<img width="1298" alt="image" src="https://user-images.githubusercontent.com/2828721/205930319-a2c97a39-4da0-40c2-b89c-2b15be7d8977.png">

## More details
- Dynamic theming was just recently-ish added to admin portal, so the `bg-brand-primary` class that was already on the `SearchHeader` component began to apply a style change once that class name had meaning within the admin portal MFE.
- It does not affect explore catalog because that MFE does need to support dynamic theming, so the class name there has no styles associated with it.
- In the learner portal, we use the `inverse` variant and actually _do_ want the background to be the enterprise's theme color. To keep support for learner portal, but fix for the other MFEs, the `bg-brand-primary` class will only be applied when `variant="inverse"`, which is only true for the learner portal.

**Merge checklist:**
- [x] Evaluate how your changes will impact existing consumers (e.g., `frontend-app-learner-portal-enterprise`, `frontend-app-admin-portal`, and `frontend-app-enterprise-public-catalog`). Will consumers safely be able to upgrade to this change without any breaking changes?
- [x] Ensure your commit message follows the semantic-release conventional commit message format. If your changes include a breaking change, ensure your commit message is explicitly marked as a `BREAKING CHANGE` so the NPM package is released as such.
- [x] Once CI is passing, verify the package versions that Lerna will increment to in the Github Action CI workflow logs.
    - *Note*: This may be found in the "Preview Updated Versions (dry run)" step in the Github Action CI workflow logs.

**Post merge:**
- [ ] Verify Lerna created a release commit (e.g., ``chore(release): publish``) that incremented versions in relevant package.json and CHANGELOG files, and created [Git tags](https://github.com/edx/frontend-enterprise/tags) for those versions.
- [ ] Run the ``Publish from package.json`` Github Action [workflow](https://github.com/edx/frontend-enterprise/actions/workflows/publish-from-package.yml) to publish these new package versions to NPM.
    - This may be triggered by clicking the "Run workflow" option for the ``master`` branch.
- [ ] Verify the new package versions were published to NPM (i.e., ``npm view <package_name> versions --json``).
    - *Note*: There may be a slight delay between when the workflow finished and when NPM reports the package version as being published. If it doesn't appear right away in the above command, try again in a few minutes.
