### PR TITLE
chore: remove --conventional-prerelease from lerna command line

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           git push -f origin automation/lerna/version
       - name: Increment Versions of Changed Packages
         run: | 
-          npx lerna@6 version --yes --allow-branch automation/lerna/version --git-remote origin --conventional-commits --conventional-prerelease --create-release github --no-push
+          npx lerna@6 version --yes --allow-branch automation/lerna/version --git-remote origin --conventional-commits --create-release github --no-push
           git status
           git --no-pager diff
         env:


### PR DESCRIPTION
This enables the package versioning we want, not pre-release alpha stuff.