### PR TITLE
feat: bump frontend-platform to 4.2.0

### DIFF
--- a/packages/catalog-search/CHANGELOG.md
+++ b/packages/catalog-search/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.1.0](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-utils@4.0.0...@edx/frontend-enterprise-utils@4.1.0) (2023-05-11)
+
+### Features
+
+* Bump frontend-platform to 4.2.0 ([#329](https://github.com/openedx/frontend-enterprise/pull/329))
+
+
 ## [4.0.0](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-catalog-search@3.1.5...@edx/frontend-enterprise-catalog-search@4.0.0) (2023-05-09)
 
 

--- a/packages/catalog-search/package.json
+++ b/packages/catalog-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-enterprise-catalog-search",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Components related to Enterprise catalog search.",
   "repository": {
     "type": "git",
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@edx/browserslist-config": "1.1.0",
     "@edx/frontend-build": "12.7.0",
-    "@edx/frontend-platform": "4.0.1",
+    "@edx/frontend-platform": "4.2.0",
     "@edx/paragon": "19.25.1",
     "@fortawesome/free-solid-svg-icons": "5.8.1",
     "@fortawesome/react-fontawesome": "0.1.4",
@@ -60,7 +60,7 @@
     "react-test-renderer": "16.14.0"
   },
   "peerDependencies": {
-    "@edx/frontend-platform": "^4.0.1",
+    "@edx/frontend-platform": "^4.2.0",
     "@edx/paragon": "^19.15.0 || ^20.0.0",
     "@fortawesome/free-solid-svg-icons": "^5.8.1",
     "@fortawesome/react-fontawesome": "^0.1.4",

--- a/packages/logistration/CHANGELOG.md
+++ b/packages/logistration/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.1.0](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-logistration@3.0.0...@edx/frontend-enterprise-logistration@3.1.0) (2023-05-11)
+
+### Features
+
+* Bump frontend-platform to 4.2.0 ([#329](https://github.com/openedx/frontend-enterprise/pull/329))
+
 ## [3.0.0](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-logistration@2.1.1...@edx/frontend-enterprise-logistration@3.0.0) (2023-05-09)
 
 

--- a/packages/logistration/package.json
+++ b/packages/logistration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-enterprise-logistration",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Enterprise-specific component(s) to ensure enterprise users are redirected to branded enterprise logistration flow.",
   "repository": {
     "type": "git",
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@edx/browserslist-config": "1.1.0",
     "@edx/frontend-build": "12.7.0",
-    "@edx/frontend-platform": "4.0.1",
+    "@edx/frontend-platform": "4.2.0",
     "@testing-library/jest-dom": "5.11.6",
     "@testing-library/react": "11.2.6",
     "react": "16.12.0",
@@ -52,7 +52,7 @@
     "react-test-renderer": "16.12.0"
   },
   "peerDependencies": {
-    "@edx/frontend-platform": "^4.0.1",
+    "@edx/frontend-platform": "^4.2.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-router-dom": "^5.2.0"

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+
+## [3.1.0](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-utils@3.0.0...@edx/frontend-enterprise-utils@3.1.0) (2023-05-11)
+
+
+### Features
+
+* Bump frontend-platform to 4.2.0 ([#329](https://github.com/openedx/frontend-enterprise/pull/329))
+
+
 ## [3.0.0](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-utils@2.2.0...@edx/frontend-enterprise-utils@3.0.0) (2023-05-09)
 
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-enterprise-utils",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Utils and other miscellaneous enterprise things.",
   "repository": {
     "type": "git",
@@ -43,14 +43,14 @@
   "devDependencies": {
     "@edx/browserslist-config": "1.1.0",
     "@edx/frontend-build": "12.7.0",
-    "@edx/frontend-platform": "4.0.1",
+    "@edx/frontend-platform": "4.2.0",
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "react-router-dom": "5.2.0",
     "react-test-renderer": "16.14.0"
   },
   "peerDependencies": {
-    "@edx/frontend-platform": "^4.0.1",
+    "@edx/frontend-platform": "^4.2.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-router-dom": "^5.2.0"


### PR DESCRIPTION
-------
#### Please re-create this PR. I don't have npm publish access therefore CI fails.
-------

This unblocks dependant packages that needs the `intl-imports.js` script in frontend-platform such as https://github.com/openedx/frontend-app-admin-portal/pull/973.

This work is part of [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

**Merge checklist:**
- [ ] Evaluate how your changes will impact existing consumers (e.g., `frontend-app-learner-portal-enterprise`, `frontend-app-admin-portal`, and `frontend-app-enterprise-public-catalog`). Will consumers safely be able to upgrade to this change without any breaking changes?
- [ ] Ensure your commit message follows the semantic-release conventional commit message format. If your changes include a breaking change, ensure your commit message is explicitly marked as a `BREAKING CHANGE` so the NPM package is released as such.
- [ ] Once CI is passing, verify the package versions that Lerna will increment to in the Github Action CI workflow logs.
    - *Note*: This may be found in the "Preview Updated Versions (dry run)" step in the Github Action CI workflow logs.

**Post merge:**
- [ ] Verify Lerna created a release commit (e.g., ``chore(release): publish``) that incremented versions in relevant package.json and CHANGELOG files, and created [Git tags](https://github.com/openedx/frontend-enterprise/tags) for those versions.
- [ ] Run the ``Publish from package.json`` Github Action [workflow](https://github.com/openedx/frontend-enterprise/actions/workflows/publish-from-package.yml) to publish these new package versions to NPM.
    - This may be triggered by clicking the "Run workflow" option for the ``master`` branch.
- [ ] Verify the new package versions were published to NPM (i.e., ``npm view <package_name> versions --json``).
    - *Note*: There may be a slight delay between when the workflow finished and when NPM reports the package version as being published. If it doesn't appear right away in the above command, try again in a few minutes.


References
----------

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Up-to-date project overview and details are available in the [Approach Memo and Technical Discovery: Translations Infrastructure Implementation](https://docs.google.com/document/d/11dFBCnbdHiCEdZp3pZeHdeH8m7Glla-XbIin7cnIOzU/edit#) document.

Join the conversation on [Open edX Slack #translations-project-fc-0012](https://openedx.slack.com/archives/C04R6TUJB7T).

Check the links above for full information about the overall project.

Internalization is being rearchitected in Open edX Python, XBlock, Micro-frontend, and other projects. There are a number of immediately visible changes:
 - Remove source and language translations from the repositories, hence no `.json`, `.po` or `.mo` files will be committed into the repos.
 - Add standardized `make extract_translations` in all repositories
 - Push user-facing messages strings into [openedx/openedx-translations](https://github.com/openedx/openedx-translations/).
 - Integrate root repositories with [openedx/openedx-atlas](https://github.com/openedx/openedx-atlas/) to pull translations on build/deploy time

Breaking Changes
----------------

One of the primary goals of the project is to **avoid breaking changes**. If you noticed any suspicious code, please raise your concern.