### PR TITLE
fix: missing space in search

### DIFF
--- a/packages/catalog-search/src/styles/_SearchSuggestions.scss
+++ b/packages/catalog-search/src/styles/_SearchSuggestions.scss
@@ -29,6 +29,9 @@
   &:hover{
     color: white;
   }
+  &:not(:first-child) {
+    margin-left: 4px; // add space between _highlightResult.title.value hits
+  }
 }
   div{
     display: flex;

--- a/packages/catalog-search/src/tests/SearchSuggestionItem.test.jsx
+++ b/packages/catalog-search/src/tests/SearchSuggestionItem.test.jsx
@@ -1,0 +1,115 @@
+import { renderWithRouter } from '@edx/frontend-enterprise-utils';
+import React from 'react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SearchSuggestionItem from '../SearchSuggestionItem';
+
+describe('<SeachSuggestionItem />', () => {
+  test('renders course data', () => {
+    const mockData = {
+      course: {
+        url: '/test-enterprise/course/edX+courseX',
+        suggestionItemHandler: jest.fn(),
+        disableSuggestionRedirect: true,
+        hit: {
+          content_type: 'course',
+          key: 'edX+courseX',
+          title: 'test-course',
+          _highlightResult: { title: { value: '<em>course</em> <em>catalog</em>' } },
+        },
+      },
+    };
+
+    renderWithRouter(<SearchSuggestionItem
+      url={mockData.course.url}
+      suggestionItemHandler={mockData.course.suggestionItemHandler}
+      hit={mockData.course.hit}
+      disableSuggestionRedirect={mockData.course.disableSuggestionRedirect}
+    />);
+    expect(screen.getByRole('link', { name: 'course catalog edX' })).not.toBeNull();
+    expect(screen.getByText('course')).not.toBeNull();
+    expect(screen.getByText('catalog')).not.toBeNull();
+    expect(screen.getByText('edX')).not.toBeNull();
+  });
+
+  test('renders program data', () => {
+    const mockData = {
+      program: {
+        url: '/test-enterprise/program/456',
+        suggestionItemHandler: jest.fn(),
+        disableSuggestionRedirect: true,
+        hit: {
+          content_type: 'program',
+          program_type: 'Professional Program',
+          key: 'edX+programX',
+          title: 'test-program',
+          _highlightResult: { title: { value: '<em>program</em> <em>catalog</em>' } },
+        },
+      },
+    };
+
+    renderWithRouter(<SearchSuggestionItem
+      url={mockData.program.url}
+      suggestionItemHandler={mockData.program.suggestionItemHandler}
+      hit={mockData.program.hit}
+      disableSuggestionRedirect={mockData.program.disableSuggestionRedirect}
+    />);
+    expect(screen.getByRole('link', { name: 'program catalog edX Professional Program' })).not.toBeNull();
+    expect(screen.getByText('program')).not.toBeNull();
+    expect(screen.getByText('catalog')).not.toBeNull();
+    expect(screen.getByText('edX')).not.toBeNull();
+    expect(screen.getByText('Professional Program')).not.toBeNull();
+  });
+
+  test('redirects on click if disableSuggestionRedirect is false', () => {
+    const mockData = {
+      program: {
+        url: '/test-enterprise/program/456',
+        suggestionItemHandler: jest.fn(),
+        disableSuggestionRedirect: false,
+        hit: {
+          content_type: 'program',
+          program_type: 'Professional Program',
+          key: 'edX+programX',
+          title: 'test-program',
+          _highlightResult: { title: { value: '<em>program</em> <em>catalog</em>' } },
+        },
+      },
+    };
+
+    const { container, history } = renderWithRouter(<SearchSuggestionItem
+      url={mockData.program.url}
+      suggestionItemHandler={mockData.program.suggestionItemHandler}
+      hit={mockData.program.hit}
+      disableSuggestionRedirect={mockData.program.disableSuggestionRedirect}
+    />);
+    userEvent.click(container.getElementsByClassName('suggestion-item')[0]);
+    expect(history.location.pathname).toBe(mockData.program.url);
+  });
+
+  test('fires callback on click if disableSuggestionRedirect is true', () => {
+    const mockData = {
+      program: {
+        url: '/test-enterprise/program/456',
+        suggestionItemHandler: jest.fn(),
+        disableSuggestionRedirect: true,
+        hit: {
+          content_type: 'program',
+          program_type: 'Professional Program',
+          key: 'edX+programX',
+          title: 'test-program',
+          _highlightResult: { title: { value: '<em>program</em> <em>catalog</em>' } },
+        },
+      },
+    };
+
+    const { container } = renderWithRouter(<SearchSuggestionItem
+      url={mockData.program.url}
+      suggestionItemHandler={mockData.program.suggestionItemHandler}
+      hit={mockData.program.hit}
+      disableSuggestionRedirect={mockData.program.disableSuggestionRedirect}
+    />);
+    userEvent.click(container.getElementsByClassName('suggestion-item')[0]);
+    expect(mockData.program.suggestionItemHandler).toHaveBeenCalledWith(mockData.program.hit);
+  });
+});


### PR DESCRIPTION
## Description
**Problem**: The typeahead in search on the explore catalog has some minor formatting/spacing  issues in course and program titles. the first two words in the title are mashed together and are both made bold. Just makes for some potentially confusing reading. 

**Solution**: Add `margin-left` to create a space between matching results. 

| Before |
| ------------- |
| <img width="991" alt="Screenshot 2023-05-30 at 11 55 15 AM" src="https://github.com/openedx/frontend-enterprise/assets/71999631/2be6b5c6-79d7-443d-b543-d2c1c2225c86">|  

| After |
| ------------- |
|<img width="985" alt="Screenshot 2023-05-30 at 11 51 16 AM" src="https://github.com/openedx/frontend-enterprise/assets/71999631/4d3cc126-0429-46f9-9d7e-76336a0d1782">|

Ticket Link
Link to the associated ticket
[Weird Formatting/Missing Spaces in Search on Explore Catalog](https://2u-internal.atlassian.net/browse/ENT-6984)

**Merge checklist:**
- [ ] Evaluate how your changes will impact existing consumers (e.g., `frontend-app-learner-portal-enterprise`, `frontend-app-admin-portal`, and `frontend-app-enterprise-public-catalog`). Will consumers safely be able to upgrade to this change without any breaking changes?
- [ ] Ensure your commit message follows the semantic-release conventional commit message format. If your changes include a breaking change, ensure your commit message is explicitly marked as a `BREAKING CHANGE` so the NPM package is released as such.
- [ ] Once CI is passing, verify the package versions that Lerna will increment to in the Github Action CI workflow logs.
    - *Note*: This may be found in the "Preview Updated Versions (dry run)" step in the Github Action CI workflow logs.

**Post merge:**
- [ ] Verify Lerna created a release commit (e.g., ``chore(release): publish``) that incremented versions in relevant package.json and CHANGELOG files, and created [Git tags](https://github.com/openedx/frontend-enterprise/tags) for those versions.
- [ ] Run the ``Publish from package.json`` Github Action [workflow](https://github.com/openedx/frontend-enterprise/actions/workflows/publish-from-package.yml) to publish these new package versions to NPM.
    - This may be triggered by clicking the "Run workflow" option for the ``master`` branch.
- [ ] Verify the new package versions were published to NPM (i.e., ``npm view <package_name> versions --json``).
    - *Note*: There may be a slight delay between when the workflow finished and when NPM reports the package version as being published. If it doesn't appear right away in the above command, try again in a few minutes.
