### PR TITLE
ENT-7171: Updated course link for executive education courses.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ To install a new NPM module in one or more specific workspace package(s), use th
 Installing local monorepo package(s) into an Open edX micro-frontend
 -----
 
-For any micro-frontend using `@edx/frontend-build <https://github.com/openedx/frontend-build>` that consumes any packages from this monorepo may want to use a local copy of one or more packages during development rather than relying solely on the published NPM packages. To do this, you may modify your module.config.js file to create Webpack aliases to your local checkout of the monorepo packages:
+For any micro-frontend using `@edx/frontend-build <https://github.com/openedx/frontend-build>` that consumes any packages from this monorepo may want to use a local copy of one or more packages during development rather than relying solely on the published NPM packages. To do this, you may modify your module.config.js file (create module.config.js if it does not already exist) to create Webpack aliases to your local checkout of the monorepo packages:
 
 ::
 

--- a/packages/catalog-search/src/SearchSuggestions.jsx
+++ b/packages/catalog-search/src/SearchSuggestions.jsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { MAX_NUM_SUGGESTIONS } from './data/constants';
+import {
+  MAX_NUM_SUGGESTIONS, LEARNING_TYPE_COURSE, LEARNING_TYPE_PROGRAM,
+  LEARNING_TYPE_EXECUTIVE_EDUCATION, COURSE_TYPE_EXECUTIVE_EDUCATION,
+} from './data/constants';
 import SearchSuggestionItem from './SearchSuggestionItem';
 
 const SearchSuggestions = ({
@@ -11,7 +14,14 @@ const SearchSuggestions = ({
   handleSuggestionClickSubmit,
   disableSuggestionRedirect,
 }) => {
-  const getLinkToCourse = (course) => `/${enterpriseSlug}/course/${course.key}`;
+  const getLinkToCourse = (course) => {
+    const { learning_type: learningType } = course;
+    if (learningType === LEARNING_TYPE_EXECUTIVE_EDUCATION) {
+      return `/${enterpriseSlug}/${COURSE_TYPE_EXECUTIVE_EDUCATION}/course/${course.key}`;
+    }
+
+    return `/${enterpriseSlug}/course/${course.key}`;
+  };
   const getLinkToProgram = (program) => `/${enterpriseSlug}/program/${program.aggregation_key.split(':').pop()}`;
 
   const courses = [];
@@ -19,9 +29,9 @@ const SearchSuggestions = ({
   const execEdCourses = [];
   autoCompleteHits.forEach((hit) => {
     const { learning_type: learningType } = hit;
-    if (learningType === 'course') { courses.push(hit); }
-    if (learningType === 'program') { programs.push(hit); }
-    if (learningType === 'Executive Education') { execEdCourses.push(hit); }
+    if (learningType === LEARNING_TYPE_COURSE) { courses.push(hit); }
+    if (learningType === LEARNING_TYPE_PROGRAM) { programs.push(hit); }
+    if (learningType === LEARNING_TYPE_EXECUTIVE_EDUCATION) { execEdCourses.push(hit); }
   });
   return (
     <div className="suggestions" data-testid="suggestions">
@@ -63,9 +73,7 @@ const SearchSuggestions = ({
           }
         </div>
       )}
-      {/* Currently (Feb 2023) it is not possible to redirect to the learner portal for exec ed content so only display
-       if the redirect is disabled */}
-      {execEdCourses.length > 0 && disableSuggestionRedirect && (
+      {execEdCourses.length > 0 && (
         <div>
           <div className="mb-2 mt-5 ml-2 font-weight-bold suggestions-section">
             Executive Education

--- a/packages/catalog-search/src/data/constants.js
+++ b/packages/catalog-search/src/data/constants.js
@@ -98,6 +98,10 @@ export const STYLE_VARIANTS = {
 export const LEARNING_TYPE_COURSE = 'course';
 export const LEARNING_TYPE_PROGRAM = 'program';
 export const LEARNING_TYPE_PATHWAY = 'learnerpathway';
+export const LEARNING_TYPE_EXECUTIVE_EDUCATION = 'Executive Education';
+
+export const COURSE_TYPE_EXECUTIVE_EDUCATION = 'executive-education-2u';
+
 export const ALGOLIA_ATTRIBUTES_TO_RETRIEVE = ['*'];
 
 export const SEARCH_BOX_CLASS_NAME = 'search-box-input';

--- a/packages/catalog-search/src/tests/SearchSuggestions.test.jsx
+++ b/packages/catalog-search/src/tests/SearchSuggestions.test.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import SearchSuggestions from '../SearchSuggestions';
+import { COURSE_TYPE_EXECUTIVE_EDUCATION } from '../data/constants';
 
 const fakeSuggestionsData = {
   nbHits: 2,
@@ -118,22 +119,15 @@ describe('<SeachSuggestions />', () => {
     expect(history.location.pathname).toBe('/test-enterprise/program/456');
   });
   test('properly handles exec ed content', () => {
-    renderWithRouter(<SearchSuggestions
+    const { container } = renderWithRouter(<SearchSuggestions
       enterpriseSlug="test-enterprise"
       autoCompleteHits={fakeSuggestionsDataOnlyExecEd.hits}
       handleSubmit={handleSubmit}
       disableSuggestionRedirect
     />);
     expect(screen.getByText('Executive Education')).not.toBeNull();
-  });
-  test('does not display exec ed content without disabling redirect', () => {
-    renderWithRouter(<SearchSuggestions
-      enterpriseSlug="test-enterprise"
-      autoCompleteHits={fakeSuggestionsDataOnlyExecEd.hits}
-      handleSubmit={handleSubmit}
-      disableSuggestionRedirect={false}
-    />);
-    expect(() => { screen.getByText('Executive Education'); }).toThrow();
+    expect(container.getElementsByClassName('suggestion-item')[0].href)
+      .toMatch(`http://localhost/test-enterprise/${COURSE_TYPE_EXECUTIVE_EDUCATION}/course/harvard+programX`);
   });
   test('does not display containers it does not have results for', () => {
     renderWithRouter(<SearchSuggestions


### PR DESCRIPTION
__Jira Ticket:__ [ENT-7171](https://2u-internal.atlassian.net/browse/ENT-7171)

__Description:__
Executive Education redirects should point towards the learner portal when supported.

**Acceptance Criteria:** 
1. address [this](https://github.com/openedx/frontend-enterprise/pull/288/files#diff-14b69db7fa3f4c28463a4e2b2f228d220af050df013b750c0f039e15328b3d94R66-R67) todo within the frontend-enterprise utils package to allow for executive education suggested search to redirect to the enterprise learner portal.

Note that this will require updating the executive education section of the component’s usage of getLinkToCourse to account for the `executive-education-2u/course/<course_key>` learner portal route.


**Merge checklist:**
- [ ] Evaluate how your changes will impact existing consumers (e.g., `frontend-app-learner-portal-enterprise`, `frontend-app-admin-portal`, and `frontend-app-enterprise-public-catalog`). Will consumers safely be able to upgrade to this change without any breaking changes?
- [ ] Ensure your commit message follows the semantic-release conventional commit message format. If your changes include a breaking change, ensure your commit message is explicitly marked as a `BREAKING CHANGE` so the NPM package is released as such.
- [ ] Once CI is passing, verify the package versions that Lerna will increment to in the Github Action CI workflow logs.
    - *Note*: This may be found in the "Preview Updated Versions (dry run)" step in the Github Action CI workflow logs.

**Post merge:**
- [ ] Verify Lerna created a release commit (e.g., ``chore(release): publish``) that incremented versions in relevant package.json and CHANGELOG files, and created [Git tags](https://github.com/openedx/frontend-enterprise/tags) for those versions.
- [ ] Run the ``Publish from package.json`` Github Action [workflow](https://github.com/openedx/frontend-enterprise/actions/workflows/publish-from-package.yml) to publish these new package versions to NPM.
    - This may be triggered by clicking the "Run workflow" option for the ``master`` branch.
- [ ] Verify the new package versions were published to NPM (i.e., ``npm view <package_name> versions --json``).
    - *Note*: There may be a slight delay between when the workflow finished and when NPM reports the package version as being published. If it doesn't appear right away in the above command, try again in a few minutes.
