### PR TITLE
chore: replace font-awesome with paragon icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2930,28 +2930,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/@fortawesome/free-solid-svg-icons": {
-      "version": "5.8.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.8.1.tgz",
-      "integrity": "sha512-FUcxR75PtMOo3ihRHJOZz64IsWIVdWgB2vCMLJjquTv487wVVCMH5H5gWa72et2oI9lKKD2jvjQ+y+7mxhscVQ==",
-      "dev": true,
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "^0.2.17"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/free-solid-svg-icons/node_modules/@fortawesome/fontawesome-common-types": {
-      "version": "0.2.36",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz",
-      "integrity": "sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@fortawesome/react-fontawesome": {
       "version": "0.1.19",
       "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.19.tgz",
@@ -27287,8 +27265,6 @@
         "@edx/frontend-build": "12.7.0",
         "@edx/frontend-platform": "4.6.0",
         "@edx/paragon": "20.45.0",
-        "@fortawesome/free-solid-svg-icons": "5.8.1",
-        "@fortawesome/react-fontawesome": "0.2.0",
         "@testing-library/jest-dom": "5.11.6",
         "@testing-library/react": "12.1.4",
         "@testing-library/react-hooks": "3.4.2",
@@ -27302,43 +27278,11 @@
       "peerDependencies": {
         "@edx/frontend-platform": "^4.0.1",
         "@edx/paragon": "^19.15.0 || ^20.0.0",
-        "@fortawesome/free-solid-svg-icons": "^5.8.1",
-        "@fortawesome/react-fontawesome": "^0.1.4",
         "react": "^16.12.0 || ^17.0.0",
         "react-dom": "^16.12.0 || ^17.0.0",
         "react-instantsearch-dom": "^6.8.3",
         "react-router-dom": "^5.2.0"
       }
-    },
-    "packages/catalog-search/node_modules/@fortawesome/react-fontawesome": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
-      "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
-      "dev": true,
-      "dependencies": {
-        "prop-types": "^15.8.1"
-      },
-      "peerDependencies": {
-        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
-        "react": ">=16.3"
-      }
-    },
-    "packages/catalog-search/node_modules/@fortawesome/react-fontawesome/node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
-    "packages/catalog-search/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
     },
     "packages/hotjar": {
       "name": "@edx/frontend-enterprise-hotjar",

--- a/packages/catalog-search/package.json
+++ b/packages/catalog-search/package.json
@@ -47,8 +47,6 @@
     "@edx/frontend-build": "12.7.0",
     "@edx/frontend-platform": "4.6.0",
     "@edx/paragon": "20.45.0",
-    "@fortawesome/free-solid-svg-icons": "5.8.1",
-    "@fortawesome/react-fontawesome": "0.2.0",
     "@testing-library/jest-dom": "5.11.6",
     "@testing-library/react": "12.1.4",
     "@testing-library/react-hooks": "3.4.2",
@@ -62,8 +60,6 @@
   "peerDependencies": {
     "@edx/frontend-platform": "^4.0.1",
     "@edx/paragon": "^19.15.0 || ^20.0.0",
-    "@fortawesome/free-solid-svg-icons": "^5.8.1",
-    "@fortawesome/react-fontawesome": "^0.1.4",
     "react": "^16.12.0 || ^17.0.0",
     "react-dom": "^16.12.0 || ^17.0.0",
     "react-instantsearch-dom": "^6.8.3",

--- a/packages/catalog-search/src/CurrentRefinements.jsx
+++ b/packages/catalog-search/src/CurrentRefinements.jsx
@@ -4,9 +4,8 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import { Badge, Button } from '@edx/paragon';
+import { CloseSmall } from '@edx/paragon/icons';
 import { connectCurrentRefinements } from 'react-instantsearch-dom';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTimes } from '@fortawesome/free-solid-svg-icons';
 
 import ClearCurrentRefinements from './ClearCurrentRefinements';
 
@@ -86,7 +85,7 @@ export const CurrentRefinementsBase = ({ items, variant }) => {
           >
             {/* Temporary fix : can be removed when learnerpathway content type is changed to pathways */}
             <span className="mr-2">{item.label === LEARNING_TYPE_PATHWAY ? 'Pathway' : item.label}</span>
-            <FontAwesomeIcon icon={faTimes} />
+            <CloseSmall />
             <span className="sr-only">Remove the filter {item.label}</span>
           </Badge>
         </li>
@@ -94,7 +93,7 @@ export const CurrentRefinementsBase = ({ items, variant }) => {
       {!showAllRefinements && activeRefinementsAsFlatArray.length > NUM_CURRENT_REFINEMENTS_TO_DISPLAY && (
         <li className="mr-2">
           <Badge
-            className={classNames('fe__refinement-badge mb-2 py-2 font-weight-light', { 'fe__refinement-badge--default': variant === STYLE_VARIANTS.defualt })}
+            className={classNames('fe__refinement-badge mb-2 py-2 font-weight-light justify-center', { 'fe__refinement-badge--default': variant === STYLE_VARIANTS.defualt })}
             variant="light"
             onClick={() => setShowAllRefinements(true)}
           >

--- a/packages/catalog-search/src/CurrentRefinements.jsx
+++ b/packages/catalog-search/src/CurrentRefinements.jsx
@@ -93,7 +93,7 @@ export const CurrentRefinementsBase = ({ items, variant }) => {
       {!showAllRefinements && activeRefinementsAsFlatArray.length > NUM_CURRENT_REFINEMENTS_TO_DISPLAY && (
         <li className="mr-2">
           <Badge
-            className={classNames('fe__refinement-badge mb-2 py-2 font-weight-light justify-center', { 'fe__refinement-badge--default': variant === STYLE_VARIANTS.defualt })}
+            className={classNames('fe__refinement-badge mb-2 py-2 font-weight-light fe_current-icon-justify-center', { 'fe__refinement-badge--default': variant === STYLE_VARIANTS.defualt })}
             variant="light"
             onClick={() => setShowAllRefinements(true)}
           >

--- a/packages/catalog-search/src/MobileFilterMenu.jsx
+++ b/packages/catalog-search/src/MobileFilterMenu.jsx
@@ -1,10 +1,9 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTimes, faCaretDown } from '@fortawesome/free-solid-svg-icons';
 import { connectCurrentRefinements } from 'react-instantsearch-dom';
 import { Button } from '@edx/paragon';
+import { ArrowDropDown, Close } from '@edx/paragon/icons';
 
 import ClearCurrentRefinements from './ClearCurrentRefinements';
 
@@ -30,7 +29,7 @@ export const MobileFilterMenuBase = ({ children, className, items }) => {
               </span>
             )}
           </div>
-          <FontAwesomeIcon icon={faCaretDown} />
+          <ArrowDropDown />
         </Button>
       )}
       <div
@@ -58,8 +57,7 @@ export const MobileFilterMenuBase = ({ children, className, items }) => {
                 className="btn-close position-absolute px-2"
                 onClick={() => setIsOpen(false)}
               >
-                <FontAwesomeIcon
-                  icon={faTimes}
+                <Close
                   id="icon-close-mobile-filter-menu"
                 />
                 <span className="sr-only">close filter menu</span>

--- a/packages/catalog-search/src/SearchPagination.jsx
+++ b/packages/catalog-search/src/SearchPagination.jsx
@@ -1,9 +1,8 @@
 import React, { useContext, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { connectPagination } from 'react-instantsearch-dom';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faAngleLeft, faAngleRight } from '@fortawesome/free-solid-svg-icons';
-import { Pagination } from '@edx/paragon';
+import { Pagination, Icon } from '@edx/paragon';
+import { ArrowBackIos, ArrowForwardIos } from '@edx/paragon/icons';
 
 import { SearchContext } from './SearchContext';
 import { setRefinementAction, deleteRefinementAction } from './data/actions';
@@ -19,13 +18,13 @@ export const SearchPaginationBase = ({
     () => ({
       left: (
         <>
-          <FontAwesomeIcon icon={faAngleLeft} />
+          <Icon src={ArrowBackIos} />
           <div className="sr-only">Navigate Left</div>
         </>
       ),
       right: (
         <>
-          <FontAwesomeIcon icon={faAngleRight} />
+          <Icon src={ArrowForwardIos} />
           <div className="sr-only">Navigate Right</div>
         </>
       ),

--- a/packages/catalog-search/src/styles/_CurrentRefinements.scss
+++ b/packages/catalog-search/src/styles/_CurrentRefinements.scss
@@ -11,3 +11,9 @@
 .fe__current-refinement-button--inverse {
   color: $white;
 }
+
+.justify-center {
+  height: 40px;
+  display: flex;
+  align-items: center;
+}

--- a/packages/catalog-search/src/styles/_CurrentRefinements.scss
+++ b/packages/catalog-search/src/styles/_CurrentRefinements.scss
@@ -12,7 +12,7 @@
   color: $white;
 }
 
-.justify-center {
+.fe_current-icon-justify-center {
   height: 40px;
   display: flex;
   align-items: center;


### PR DESCRIPTION
# Description
This is part of a larger effort to deprecate Font Awesome in favor of solely using Paragon Icons, which will reduce bundle size and improve performance (page load time) since it’s a larger library. 

# Solution
Replace all Font-awesome icons with Paragon icons. Before and after photos below:

`packages/catalog-search/src/CurrentRefinements.jsx`
| Before (Font-Awesome icons) | After (Paragon Icons)|
| ------------- | ------------- |
|<img width="345" alt="Screenshot 2023-08-02 at 11 45 34 PM" src="https://github.com/openedx/frontend-enterprise/assets/71999631/83d4cf08-a8fb-4948-ae2b-80f84181b852">|<img width="454" alt="Screenshot 2023-08-03 at 12 13 28 AM" src="https://github.com/openedx/frontend-enterprise/assets/71999631/37bdf7b7-b677-47bb-84fe-0f502fab42af">|

`packages/catalog-search/src/MobileFilterMenu.jsx`
| Before (Font-Awesome icons) | After (Paragon Icons)|
| ------------- | ------------- |
|<img width="253" alt="Screenshot 2023-08-03 at 12 16 23 AM" src="https://github.com/openedx/frontend-enterprise/assets/71999631/ec8d9c60-3e4b-4f2c-b15b-36d81723de1b">|<img width="255" alt="Screenshot 2023-08-03 at 12 17 11 AM" src="https://github.com/openedx/frontend-enterprise/assets/71999631/0a294099-2e84-44c6-9614-b839176bc886">|

`packages/catalog-search/src/SearchPagination.jsx`
| Before (Font-Awesome icons) | After (Paragon Icons)|
| ------------- | ------------- |
|![Screenshot 2023-08-03 at 12 01 42 PM](https://github.com/openedx/frontend-enterprise/assets/71999631/428bc99a-99bb-417b-8cf1-ee99dfb042ff)|![Screenshot 2023-08-03 at 12 03 00 PM](https://github.com/openedx/frontend-enterprise/assets/71999631/fcb028d0-8408-43f4-b6b2-8c195c58b3ca)|

[Jira Ticket](https://2u-internal.atlassian.net/browse/ENT-7430)

**Merge checklist:**
- [ ] Evaluate how your changes will impact existing consumers (e.g., `frontend-app-learner-portal-enterprise`, `frontend-app-admin-portal`, and `frontend-app-enterprise-public-catalog`). Will consumers safely be able to upgrade to this change without any breaking changes?
- [ ] Ensure your commit message follows the semantic-release conventional commit message format. If your changes include a breaking change, ensure your commit message is explicitly marked as a `BREAKING CHANGE` so the NPM package is released as such.
- [ ] Once CI is passing, verify the package versions that Lerna will increment to in the Github Action CI workflow logs.
    - *Note*: This may be found in the "Preview Updated Versions (dry run)" step in the Github Action CI workflow logs.

**Post merge:**
- [ ] Verify Lerna created a release commit (e.g., ``chore(release): publish``) that incremented versions in relevant package.json and CHANGELOG files, and created [Git tags](https://github.com/openedx/frontend-enterprise/tags) for those versions.
- [ ] Run the ``Publish from package.json`` Github Action [workflow](https://github.com/openedx/frontend-enterprise/actions/workflows/publish-from-package.yml) to publish these new package versions to NPM.
    - This may be triggered by clicking the "Run workflow" option for the ``master`` branch.
- [ ] Verify the new package versions were published to NPM (i.e., ``npm view <package_name> versions --json``).
    - *Note*: There may be a slight delay between when the workflow finished and when NPM reports the package version as being published. If it doesn't appear right away in the above command, try again in a few minutes.
