### PR TITLE
fix: bump frontend-platform

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2470,9 +2470,9 @@
       "link": true
     },
     "node_modules/@edx/frontend-platform": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-5.0.0.tgz",
-      "integrity": "sha512-DD9/B4rnC3BKPiWlbEFF1JIYFbWC6vUBKTyN8sf4khi4DNhhWhsobk+iNeCWNzF9UgCPRbniIqesdV1F9NXNZw==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-5.5.4.tgz",
+      "integrity": "sha512-Yum+oST7XfDwDnDhBnzeR/mjp6O+G0g+5AZtIJ1BdTKQH1z9FObfim/pfoiI9STiYlguVpeWMkzWuca/QMLO/Q==",
       "dev": true,
       "dependencies": {
         "@cospired/i18n-iso-languages": "4.1.0",
@@ -2501,7 +2501,7 @@
       },
       "peerDependencies": {
         "@edx/frontend-build": ">= 8.1.0 || ^12.9.0-alpha.1",
-        "@edx/paragon": ">= 10.0.0 < 21.0.0",
+        "@edx/paragon": ">= 10.0.0 < 22.0.0",
         "prop-types": "^15.7.2",
         "react": "^16.9.0 || ^17.0.0",
         "react-dom": "^16.9.0 || ^17.0.0",
@@ -27243,7 +27243,7 @@
       "devDependencies": {
         "@edx/browserslist-config": "1.1.0",
         "@edx/frontend-build": "12.7.0",
-        "@edx/frontend-platform": "5.0.0",
+        "@edx/frontend-platform": "5.5.4",
         "@edx/paragon": "21.1.6",
         "@testing-library/jest-dom": "5.11.6",
         "@testing-library/react": "12.1.4",
@@ -27424,7 +27424,7 @@
       "devDependencies": {
         "@edx/browserslist-config": "1.1.0",
         "@edx/frontend-build": "12.7.0",
-        "@edx/frontend-platform": "5.0.0",
+        "@edx/frontend-platform": "5.5.4",
         "@testing-library/jest-dom": "5.11.6",
         "@testing-library/react": "12.1.4",
         "react": "17.0.2",
@@ -27450,7 +27450,7 @@
       "devDependencies": {
         "@edx/browserslist-config": "1.1.0",
         "@edx/frontend-build": "12.7.0",
-        "@edx/frontend-platform": "5.0.0",
+        "@edx/frontend-platform": "5.5.4",
         "react": "17.0.2",
         "react-dom": "17.0.2",
         "react-router-dom": "6.14.2",

--- a/packages/catalog-search/package.json
+++ b/packages/catalog-search/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@edx/browserslist-config": "1.1.0",
     "@edx/frontend-build": "12.7.0",
-    "@edx/frontend-platform": "5.0.0",
+    "@edx/frontend-platform": "5.5.4",
     "@edx/paragon": "21.1.6",
     "@testing-library/jest-dom": "5.11.6",
     "@testing-library/react": "12.1.4",

--- a/packages/logistration/package.json
+++ b/packages/logistration/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@edx/browserslist-config": "1.1.0",
     "@edx/frontend-build": "12.7.0",
-    "@edx/frontend-platform": "5.0.0",
+    "@edx/frontend-platform": "5.5.4",
     "@testing-library/jest-dom": "5.11.6",
     "@testing-library/react": "12.1.4",
     "react": "17.0.2",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@edx/browserslist-config": "1.1.0",
     "@edx/frontend-build": "12.7.0",
-    "@edx/frontend-platform": "5.0.0",
+    "@edx/frontend-platform": "5.5.4",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-router-dom": "6.14.2",


### PR DESCRIPTION
# Description
This PR resolves the `PUBLIC_PATH` configuration issue by upgrading frontend-platform from `v5.0.0` to `v5.5.4`.

**Merge checklist:**
- [ ] Evaluate how your changes will impact existing consumers (e.g., `frontend-app-learner-portal-enterprise`, `frontend-app-admin-portal`, and `frontend-app-enterprise-public-catalog`). Will consumers safely be able to upgrade to this change without any breaking changes?
- [ ] Ensure your commit message follows the semantic-release conventional commit message format. If your changes include a breaking change, ensure your commit message is explicitly marked as a `BREAKING CHANGE` so the NPM package is released as such.
- [ ] Once CI is passing, verify the package versions that Lerna will increment to in the Github Action CI workflow logs.
    - *Note*: This may be found in the "Preview Updated Versions (dry run)" step in the Github Action CI workflow logs.

**Post merge:**
- [ ] Verify Lerna created a release commit (e.g., ``chore(release): publish``) that incremented versions in relevant package.json and CHANGELOG files, and created [Git tags](https://github.com/openedx/frontend-enterprise/tags) for those versions.
- [ ] Run the ``Publish from package.json`` Github Action [workflow](https://github.com/openedx/frontend-enterprise/actions/workflows/publish-from-package.yml) to publish these new package versions to NPM.
    - This may be triggered by clicking the "Run workflow" option for the ``master`` branch.
- [ ] Verify the new package versions were published to NPM (i.e., ``npm view <package_name> versions --json``).
    - *Note*: There may be a slight delay between when the workflow finished and when NPM reports the package version as being published. If it doesn't appear right away in the above command, try again in a few minutes.
