### PR TITLE
chore(release): publish new versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27232,10 +27232,10 @@
     },
     "packages/catalog-search": {
       "name": "@edx/frontend-enterprise-catalog-search",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@edx/frontend-enterprise-utils": "^4.0.3",
+        "@edx/frontend-enterprise-utils": "^4.0.4",
         "classnames": "2.2.5",
         "lodash.debounce": "4.0.8",
         "prop-types": "15.7.2"
@@ -27415,10 +27415,10 @@
     },
     "packages/logistration": {
       "name": "@edx/frontend-enterprise-logistration",
-      "version": "4.0.3",
+      "version": "4.0.4",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@edx/frontend-enterprise-utils": "^4.0.3",
+        "@edx/frontend-enterprise-utils": "^4.0.4",
         "prop-types": "15.7.2"
       },
       "devDependencies": {
@@ -27441,7 +27441,7 @@
     },
     "packages/utils": {
       "name": "@edx/frontend-enterprise-utils",
-      "version": "4.0.3",
+      "version": "4.0.4",
       "license": "AGPL-3.0",
       "dependencies": {
         "@testing-library/react": "12.1.4",

--- a/packages/catalog-search/CHANGELOG.md
+++ b/packages/catalog-search/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.4.0](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-catalog-search@5.0.0...@edx/frontend-enterprise-catalog-search@5.4.0) (2023-10-17)
+
+
+### Features
+
+* allow Paragon v21 in catalog-search ([#356](https://github.com/openedx/frontend-enterprise/issues/356)) ([75005f5](https://github.com/openedx/frontend-enterprise/commit/75005f5e27304e3147fc141ef5dc1bc6ac64a834))
+* removing free/all filter ([#359](https://github.com/openedx/frontend-enterprise/issues/359)) ([f187fbd](https://github.com/openedx/frontend-enterprise/commit/f187fbd89eb8c6b490b8a0fafb7f192ed9dcf24c))
+
+
+### Bug Fixes
+
+* bump frontend-platform ([#363](https://github.com/openedx/frontend-enterprise/issues/363)) ([1413ef2](https://github.com/openedx/frontend-enterprise/commit/1413ef21a1736d572bddb770352f33d505242bef))
+
+
+
 ## [5.3.0](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-catalog-search@5.0.0...@edx/frontend-enterprise-catalog-search@5.3.0) (2023-09-28)
 
 

--- a/packages/catalog-search/package.json
+++ b/packages/catalog-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-enterprise-catalog-search",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "description": "Components related to Enterprise catalog search.",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@edx/frontend-enterprise-utils": "^4.0.3",
+    "@edx/frontend-enterprise-utils": "^4.0.4",
     "classnames": "2.2.5",
     "lodash.debounce": "4.0.8",
     "prop-types": "15.7.2"

--- a/packages/logistration/CHANGELOG.md
+++ b/packages/logistration/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.0.4](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-logistration@4.0.0...@edx/frontend-enterprise-logistration@4.0.4) (2023-10-17)
+
+
+### Bug Fixes
+
+* bump frontend-platform ([#363](https://github.com/openedx/frontend-enterprise/issues/363)) ([1413ef2](https://github.com/openedx/frontend-enterprise/commit/1413ef21a1736d572bddb770352f33d505242bef))
+
+
+
 ## [4.0.3](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-logistration@4.0.0...@edx/frontend-enterprise-logistration@4.0.3) (2023-09-28)
 
 **Note:** Version bump only for package @edx/frontend-enterprise-logistration

--- a/packages/logistration/package.json
+++ b/packages/logistration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-enterprise-logistration",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "Enterprise-specific component(s) to ensure enterprise users are redirected to branded enterprise logistration flow.",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@edx/frontend-enterprise-utils": "^4.0.3",
+    "@edx/frontend-enterprise-utils": "^4.0.4",
     "prop-types": "15.7.2"
   },
   "devDependencies": {

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.0.4](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-utils@4.0.0...@edx/frontend-enterprise-utils@4.0.4) (2023-10-17)
+
+
+### Bug Fixes
+
+* bump frontend-platform ([#363](https://github.com/openedx/frontend-enterprise/issues/363)) ([1413ef2](https://github.com/openedx/frontend-enterprise/commit/1413ef21a1736d572bddb770352f33d505242bef))
+
+
+
 ## [4.0.3](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-utils@4.0.0...@edx/frontend-enterprise-utils@4.0.3) (2023-09-28)
 
 **Note:** Version bump only for package @edx/frontend-enterprise-utils

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-enterprise-utils",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "Utils and other miscellaneous enterprise things.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
 - @edx/frontend-enterprise-catalog-search@5.4.0
 - @edx/frontend-enterprise-logistration@4.0.4
 - @edx/frontend-enterprise-utils@4.0.4

Functionally, no changes. Goal is to publish a new v5 version of `@edx/frontend-enterprise-catalog-search` so that the `latest` NPM distribution tag is updated to point at v5 rather than v4 like it is now.

**Merge checklist:**
- [ ] Evaluate how your changes will impact existing consumers (e.g., `frontend-app-learner-portal-enterprise`, `frontend-app-admin-portal`, and `frontend-app-enterprise-public-catalog`). Will consumers safely be able to upgrade to this change without any breaking changes?
- [ ] Ensure your commit message follows the semantic-release conventional commit message format. If your changes include a breaking change, ensure your commit message is explicitly marked as a `BREAKING CHANGE` so the NPM package is released as such.
- [ ] Once CI is passing, verify the package versions that Lerna will increment to in the Github Action CI workflow logs.
    - *Note*: This may be found in the "Preview Updated Versions (dry run)" step in the Github Action CI workflow logs.

**Post merge:**
- [ ] Verify Lerna created a release commit (e.g., ``chore(release): publish``) that incremented versions in relevant package.json and CHANGELOG files, and created [Git tags](https://github.com/openedx/frontend-enterprise/tags) for those versions.
- [ ] Run the ``Publish from package.json`` Github Action [workflow](https://github.com/openedx/frontend-enterprise/actions/workflows/publish-from-package.yml) to publish these new package versions to NPM.
    - This may be triggered by clicking the "Run workflow" option for the ``master`` branch.
- [ ] Verify the new package versions were published to NPM (i.e., ``npm view <package_name> versions --json``).
    - *Note*: There may be a slight delay between when the workflow finished and when NPM reports the package version as being published. If it doesn't appear right away in the above command, try again in a few minutes.
