### PR TITLE
fix: remove pathways from customers search

### DIFF
--- a/packages/catalog-search/src/LearningTypeRadioFacet.jsx
+++ b/packages/catalog-search/src/LearningTypeRadioFacet.jsx
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Dropdown, Input } from '@edx/paragon';
 import { SearchContext } from './SearchContext';
@@ -8,7 +9,7 @@ import {
 import { features } from './config';
 import { LEARNING_TYPE_COURSE, LEARNING_TYPE_PROGRAM, LEARNING_TYPE_PATHWAY } from './data/constants';
 
-const LearningTypeRadioFacet = () => {
+const LearningTypeRadioFacet = ({ enablePathways }) => {
   const { refinements, dispatch } = useContext(SearchContext);
   // only bold the dropdown title if the learning type is Course or Program
   const typeCourseSelected = refinements.content_type && refinements.content_type.includes(LEARNING_TYPE_COURSE);
@@ -72,7 +73,9 @@ const LearningTypeRadioFacet = () => {
             </span>
           </Dropdown.Item>
           {
-            features.ENABlE_PATHWAYS && (
+            // the first check is a global feature flag and the second is a check to see if
+            // the individual customer itself has enabled pathways
+            features.ENABlE_PATHWAYS && enablePathways && (
               <Dropdown.Item as="label" className="mb-0 py-3 d-flex align-items-center">
                 <Input
                   type="radio"
@@ -91,6 +94,14 @@ const LearningTypeRadioFacet = () => {
       </Dropdown>
     </div>
   );
+};
+
+LearningTypeRadioFacet.defaultProps = {
+  enablePathways: null,
+};
+
+LearningTypeRadioFacet.propTypes = {
+  enablePathways: PropTypes.bool,
 };
 
 export default LearningTypeRadioFacet;

--- a/packages/catalog-search/src/SearchFilters.jsx
+++ b/packages/catalog-search/src/SearchFilters.jsx
@@ -17,7 +17,7 @@ import LearningTypeRadioFacet from './LearningTypeRadioFacet';
 
 export const FREE_ALL_TITLE = 'Free / All';
 
-const SearchFilters = ({ variant }) => {
+const SearchFilters = ({ variant, enablePathways }) => {
   const { refinements, searchFacetFilters } = useContext(SearchContext);
 
   const searchFacets = useMemo(
@@ -48,7 +48,7 @@ const SearchFilters = ({ variant }) => {
       return (
         <>
           {filtersFromRefinements}
-          {features.LEARNING_TYPE_FACET && (<LearningTypeRadioFacet />)}
+          {features.LEARNING_TYPE_FACET && (<LearningTypeRadioFacet enablePathways={enablePathways} />)}
         </>
       );
     },
@@ -76,10 +76,12 @@ const SearchFilters = ({ variant }) => {
 
 SearchFilters.defaultProps = {
   variant: STYLE_VARIANTS.inverse,
+  enablePathways: null,
 };
 
 SearchFilters.propTypes = {
   variant: PropTypes.oneOf([STYLE_VARIANTS.default, STYLE_VARIANTS.inverse]),
+  enablePathways: PropTypes.bool,
 };
 
 export default SearchFilters;

--- a/packages/catalog-search/src/SearchHeader.jsx
+++ b/packages/catalog-search/src/SearchHeader.jsx
@@ -21,7 +21,7 @@ const SearchHeader = ({
   index,
   filters,
   suggestionSubmitOverride,
-  enterpriseConfig: { slug },
+  enterpriseConfig: { slug, enablePathways },
   disableSuggestionRedirect,
 }) => {
   const { refinements } = useContext(SearchContext);
@@ -64,7 +64,7 @@ const SearchHeader = ({
             className={classNames('fe__searchbox-col', { 'fe__searchbox-col--default': variant === STYLE_VARIANTS.default })}
             xs={12}
           >
-            <SearchFilters className="mb-3" variant={variant} />
+            <SearchFilters className="mb-3" variant={variant} enablePathways={enablePathways} />
           </Col>
         </Row>
       </Container>
@@ -78,7 +78,7 @@ SearchHeader.defaultProps = {
   headerTitle: undefined,
   hideTitle: false,
   filters: '',
-  enterpriseConfig: { slug: undefined },
+  enterpriseConfig: { slug: undefined, enablePathways: undefined },
   suggestionSubmitOverride: undefined,
   disableSuggestionRedirect: false,
   index: undefined,
@@ -91,7 +91,9 @@ SearchHeader.propTypes = {
   hideTitle: PropTypes.bool,
   index: PropTypes.shape({ search: PropTypes.func.isRequired }),
   filters: PropTypes.string,
-  enterpriseConfig: PropTypes.shape({ slug: PropTypes.string }),
+  enterpriseConfig: PropTypes.shape(
+    { slug: PropTypes.string, enablePathways: PropTypes.bool },
+  ),
   suggestionSubmitOverride: PropTypes.func,
   disableSuggestionRedirect: PropTypes.bool,
 };

--- a/packages/catalog-search/src/tests/LearningTypeRadioFacet.test.jsx
+++ b/packages/catalog-search/src/tests/LearningTypeRadioFacet.test.jsx
@@ -22,13 +22,13 @@ describe('<LearningTypeRadioFacet />', () => {
   });
 
   test('LearningTypeRadioFacet is rendered and isnt bold initially', () => {
-    renderWithSearchContext(<LearningTypeRadioFacet />);
+    renderWithSearchContext(<LearningTypeRadioFacet enablePathways />);
     expect(screen.getByText('Learning Type')).toBeInTheDocument();
     expect(screen.getByText('Learning Type').classList.contains('font-weight-bold')).toBeFalsy();
   });
 
   test('LearningTypeRadioFacet displays all the options', async () => {
-    renderWithSearchContext(<LearningTypeRadioFacet />);
+    renderWithSearchContext(<LearningTypeRadioFacet enablePathways />);
     expect(screen.getByText('Learning Type')).toBeInTheDocument();
     fireEvent.click(screen.getByText('Learning Type'));
     await waitFor(() => {
@@ -39,8 +39,20 @@ describe('<LearningTypeRadioFacet />', () => {
     });
   });
 
+  test('LearningTypeRadioFacet doesnt display pathways if false', async () => {
+    renderWithSearchContext(<LearningTypeRadioFacet enablePathways={false} />);
+    expect(screen.getByText('Learning Type')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Learning Type'));
+    await waitFor(() => {
+      expect(screen.getByText('Any')).toBeInTheDocument();
+      expect(screen.getByText('Courses')).toBeInTheDocument();
+      expect(screen.getByText('Programs')).toBeInTheDocument();
+      expect(screen.queryByText('Pathways')).not.toBeInTheDocument();
+    });
+  });
+
   test('LearningTypeRadioFacet isnt bold when content type Any is selected', async () => {
-    renderWithSearchContext(<LearningTypeRadioFacet />);
+    renderWithSearchContext(<LearningTypeRadioFacet enablePathways />);
     expect(screen.getByText('Learning Type')).toBeInTheDocument();
     fireEvent.click(screen.getByText('Learning Type'));
     await waitFor(() => {
@@ -50,7 +62,7 @@ describe('<LearningTypeRadioFacet />', () => {
   });
 
   test('LearningTypeRadioFacet is bold content type Courses is selected', async () => {
-    renderWithSearchContext(<LearningTypeRadioFacet />);
+    renderWithSearchContext(<LearningTypeRadioFacet enablePathways />);
     expect(screen.getByText('Learning Type')).toBeInTheDocument();
     fireEvent.click(screen.getByText('Learning Type'));
     fireEvent.click(screen.getByTestId('learning-type-courses'));
@@ -61,7 +73,7 @@ describe('<LearningTypeRadioFacet />', () => {
   });
 
   test('LearningTypeRadioFacet is bold content type Courses is selected', async () => {
-    renderWithSearchContext(<LearningTypeRadioFacet />);
+    renderWithSearchContext(<LearningTypeRadioFacet enablePathways />);
     expect(screen.getByText('Learning Type')).toBeInTheDocument();
     fireEvent.click(screen.getByText('Learning Type'));
     fireEvent.click(screen.getByTestId('learning-type-programs'));
@@ -72,7 +84,7 @@ describe('<LearningTypeRadioFacet />', () => {
   });
 
   test('LearningTypeRadioFacet is bold content type Courses is selected', async () => {
-    renderWithSearchContext(<LearningTypeRadioFacet />);
+    renderWithSearchContext(<LearningTypeRadioFacet enablePathways />);
     expect(screen.getByText('Learning Type')).toBeInTheDocument();
     fireEvent.click(screen.getByText('Learning Type'));
     fireEvent.click(screen.getByTestId('learning-type-pathways'));


### PR DESCRIPTION
[Jira Ticket 
](https://2u-internal.atlassian.net/browse/ENT-8123)

We use a hardcoded list for Learning Type facet dropdown. This PR has new logic to block showing pathways on enterprise customers where the 'enablePathways' boolean is false. 

**Merge checklist:**
- [x] Evaluate how your changes will impact existing consumers (e.g., `frontend-app-learner-portal-enterprise`, `frontend-app-admin-portal`, and `frontend-app-enterprise-public-catalog`). Will consumers safely be able to upgrade to this change without any breaking changes?
- [x] Ensure your commit message follows the semantic-release conventional commit message format. If your changes include a breaking change, ensure your commit message is explicitly marked as a `BREAKING CHANGE` so the NPM package is released as such.
- [ ] Once CI is passing, verify the package versions that Lerna will increment to in the Github Action CI workflow logs.
    - *Note*: This may be found in the "Preview Updated Versions (dry run)" step in the Github Action CI workflow logs.

**Post merge:**
- [ ] Verify Lerna created a release commit (e.g., ``chore(release): publish``) that incremented versions in relevant package.json and CHANGELOG files, and created [Git tags](https://github.com/openedx/frontend-enterprise/tags) for those versions.
- [ ] Run the ``Publish from package.json`` Github Action [workflow](https://github.com/openedx/frontend-enterprise/actions/workflows/publish-from-package.yml) to publish these new package versions to NPM.
    - This may be triggered by clicking the "Run workflow" option for the ``master`` branch.
- [ ] Verify the new package versions were published to NPM (i.e., ``npm view <package_name> versions --json``).
    - *Note*: There may be a slight delay between when the workflow finished and when NPM reports the package version as being published. If it doesn't appear right away in the above command, try again in a few minutes.
