### PR TITLE
chore(release): publish new versions for #367

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28148,10 +28148,10 @@
     },
     "packages/catalog-search": {
       "name": "@edx/frontend-enterprise-catalog-search",
-      "version": "5.6.0",
+      "version": "6.0.0",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@edx/frontend-enterprise-utils": "^4.1.0",
+        "@edx/frontend-enterprise-utils": "^5.0.0",
         "classnames": "2.2.5",
         "lodash.debounce": "4.0.8",
         "prop-types": "15.7.2"
@@ -28182,7 +28182,7 @@
     },
     "packages/hotjar": {
       "name": "@edx/frontend-enterprise-hotjar",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "AGPL-3.0",
       "devDependencies": {
         "@edx/browserslist-config": "1.1.0",
@@ -28199,10 +28199,10 @@
     },
     "packages/logistration": {
       "name": "@edx/frontend-enterprise-logistration",
-      "version": "4.1.0",
+      "version": "5.0.0",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@edx/frontend-enterprise-utils": "^4.1.0",
+        "@edx/frontend-enterprise-utils": "^5.0.0",
         "prop-types": "15.7.2"
       },
       "devDependencies": {
@@ -28225,7 +28225,7 @@
     },
     "packages/utils": {
       "name": "@edx/frontend-enterprise-utils",
-      "version": "4.1.0",
+      "version": "5.0.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@testing-library/react": "12.1.4",

--- a/packages/catalog-search/CHANGELOG.md
+++ b/packages/catalog-search/CHANGELOG.md
@@ -3,6 +3,54 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.0.0](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-catalog-search@3.1.5...@edx/frontend-enterprise-catalog-search@6.0.0) (2024-02-12)
+
+
+### ⚠ BREAKING CHANGES
+
+* consuming applications must now provide paragon from the @openedx scope
+
+* refactor: replace @edx/paragon and @edx/frontend-build
+
+* fix: fixed package issues
+
+* fix: updated dependency
+
+* fix: updated package lock file to fix ci issue
+
+* refactor: updated frontend-platform to v7 along with peer Dependencies
+* Upgrade react-router-dom from v5 to v6.
+Upgrade frontend-platform from v4 to v5.
+
+### Features
+
+* Add .npmrc file to more .gitignore files ([#303](https://github.com/openedx/frontend-enterprise/issues/303)) ([d890c21](https://github.com/openedx/frontend-enterprise/commit/d890c212c3f8c5ec81e6dee63f68029ad0b00552))
+* add prequery search suggestions ([#371](https://github.com/openedx/frontend-enterprise/issues/371)) ([3651ee0](https://github.com/openedx/frontend-enterprise/commit/3651ee0f0e77e461956175d98aaa4addb38a1762))
+* adding exec ed compatibility to suggested search ([#288](https://github.com/openedx/frontend-enterprise/issues/288)) ([21d608c](https://github.com/openedx/frontend-enterprise/commit/21d608ce49b764e62101b5f696b463f6800ddcb0))
+* allow Paragon v21 in catalog-search ([#356](https://github.com/openedx/frontend-enterprise/issues/356)) ([75005f5](https://github.com/openedx/frontend-enterprise/commit/75005f5e27304e3147fc141ef5dc1bc6ac64a834))
+* bumped frontend-platform to v6 ([#364](https://github.com/openedx/frontend-enterprise/issues/364)) ([1541b86](https://github.com/openedx/frontend-enterprise/commit/1541b864dc6c351ea595d9f0c5669299af3b64cc))
+* removing free/all filter ([#359](https://github.com/openedx/frontend-enterprise/issues/359)) ([f187fbd](https://github.com/openedx/frontend-enterprise/commit/f187fbd89eb8c6b490b8a0fafb7f192ed9dcf24c))
+* update react & react-dom to v17 ([#338](https://github.com/openedx/frontend-enterprise/issues/338)) ([b1b548c](https://github.com/openedx/frontend-enterprise/commit/b1b548c0ec27572d639f276507a1495b78db9497))
+* Updated course link for executive4 education courses. ([#336](https://github.com/openedx/frontend-enterprise/issues/336)) ([4212580](https://github.com/openedx/frontend-enterprise/commit/4212580f4fd6c2de4696f25e81f50f2714db1672))
+* upgrade react router to v6 ([#344](https://github.com/openedx/frontend-enterprise/issues/344)) ([54f6340](https://github.com/openedx/frontend-enterprise/commit/54f6340f764a9120bebd654564e0d61918a3cffa))
+* upgraded to node v18, added .nvmrc and updated workflows ([#306](https://github.com/openedx/frontend-enterprise/issues/306)) ([0508783](https://github.com/openedx/frontend-enterprise/commit/050878307ff5f8a94385b7f41070dec19c7e84cc))
+
+
+### Bug Fixes
+
+* Bump all versions one final time I hope.... ([#297](https://github.com/openedx/frontend-enterprise/issues/297)) ([3452d81](https://github.com/openedx/frontend-enterprise/commit/3452d810bad4b7292ce342ac96bec500809b532d))
+* bump frontend-platform ([#363](https://github.com/openedx/frontend-enterprise/issues/363)) ([1413ef2](https://github.com/openedx/frontend-enterprise/commit/1413ef21a1736d572bddb770352f33d505242bef))
+* manully bump versions after failed automation run ([#301](https://github.com/openedx/frontend-enterprise/issues/301)) ([f1e8616](https://github.com/openedx/frontend-enterprise/commit/f1e8616996c46ffda1c7596be6fc323136ac34c2))
+* missing space in search ([#333](https://github.com/openedx/frontend-enterprise/issues/333)) ([c604834](https://github.com/openedx/frontend-enterprise/commit/c604834d2efcfeba5d692e0f8dc7bb1681e72262))
+* remove pathways from customers search ([#366](https://github.com/openedx/frontend-enterprise/issues/366)) ([d4625c9](https://github.com/openedx/frontend-enterprise/commit/d4625c92443d088c2319f81ea516c2613b8d3943))
+
+
+### Miscellaneous Chores
+
+* move paragon to peer dependency using [@openedx](https://github.com/openedx) scope and upgrade frontend-platform ([#367](https://github.com/openedx/frontend-enterprise/issues/367)) ([d121d67](https://github.com/openedx/frontend-enterprise/commit/d121d67efa6e84de86a7f3eb84acb674f2d4a380))
+
+
+
 ## [5.6.0](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-catalog-search@5.0.0...@edx/frontend-enterprise-catalog-search@5.6.0) (2024-02-01)
 
 

--- a/packages/catalog-search/package.json
+++ b/packages/catalog-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-enterprise-catalog-search",
-  "version": "5.6.0",
+  "version": "6.0.0",
   "description": "Components related to Enterprise catalog search.",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@edx/frontend-enterprise-utils": "^4.1.0",
+    "@edx/frontend-enterprise-utils": "^5.0.0",
     "classnames": "2.2.5",
     "lodash.debounce": "4.0.8",
     "prop-types": "15.7.2"

--- a/packages/hotjar/CHANGELOG.md
+++ b/packages/hotjar/CHANGELOG.md
@@ -3,6 +3,45 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [3.0.0](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-hotjar@1.2.0...@edx/frontend-enterprise-hotjar@3.0.0) (2024-02-12)
+
+
+### ⚠ BREAKING CHANGES
+
+* consuming applications must now provide paragon from the @openedx scope
+
+* refactor: replace @edx/paragon and @edx/frontend-build
+
+* fix: fixed package issues
+
+* fix: updated dependency
+
+* fix: updated package lock file to fix ci issue
+
+* refactor: updated frontend-platform to v7 along with peer Dependencies
+* Upgrade react-router-dom from v5 to v6.
+Upgrade frontend-platform from v4 to v5.
+
+### Features
+
+* Add .npmrc file to more .gitignore files ([#303](https://github.com/openedx/frontend-enterprise/issues/303)) ([d890c21](https://github.com/openedx/frontend-enterprise/commit/d890c212c3f8c5ec81e6dee63f68029ad0b00552))
+* update react & react-dom to v17 ([#338](https://github.com/openedx/frontend-enterprise/issues/338)) ([b1b548c](https://github.com/openedx/frontend-enterprise/commit/b1b548c0ec27572d639f276507a1495b78db9497))
+* upgrade react router to v6 ([#344](https://github.com/openedx/frontend-enterprise/issues/344)) ([54f6340](https://github.com/openedx/frontend-enterprise/commit/54f6340f764a9120bebd654564e0d61918a3cffa))
+* upgraded to node v18, added .nvmrc and updated workflows ([#306](https://github.com/openedx/frontend-enterprise/issues/306)) ([0508783](https://github.com/openedx/frontend-enterprise/commit/050878307ff5f8a94385b7f41070dec19c7e84cc))
+
+
+### Bug Fixes
+
+* Bump all versions one final time I hope.... ([#297](https://github.com/openedx/frontend-enterprise/issues/297)) ([3452d81](https://github.com/openedx/frontend-enterprise/commit/3452d810bad4b7292ce342ac96bec500809b532d))
+* manully bump versions after failed automation run ([#301](https://github.com/openedx/frontend-enterprise/issues/301)) ([f1e8616](https://github.com/openedx/frontend-enterprise/commit/f1e8616996c46ffda1c7596be6fc323136ac34c2))
+
+
+### Miscellaneous Chores
+
+* move paragon to peer dependency using [@openedx](https://github.com/openedx) scope and upgrade frontend-platform ([#367](https://github.com/openedx/frontend-enterprise/issues/367)) ([d121d67](https://github.com/openedx/frontend-enterprise/commit/d121d67efa6e84de86a7f3eb84acb674f2d4a380))
+
+
+
 ## [2.0.0] (2023-08-15)
 
 

--- a/packages/hotjar/package.json
+++ b/packages/hotjar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-enterprise-hotjar",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Utils for Hotjar.",
   "repository": {
     "type": "git",

--- a/packages/logistration/CHANGELOG.md
+++ b/packages/logistration/CHANGELOG.md
@@ -3,6 +3,47 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.0.0](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-logistration@2.1.1...@edx/frontend-enterprise-logistration@5.0.0) (2024-02-12)
+
+
+### ⚠ BREAKING CHANGES
+
+* consuming applications must now provide paragon from the @openedx scope
+
+* refactor: replace @edx/paragon and @edx/frontend-build
+
+* fix: fixed package issues
+
+* fix: updated dependency
+
+* fix: updated package lock file to fix ci issue
+
+* refactor: updated frontend-platform to v7 along with peer Dependencies
+* Upgrade react-router-dom from v5 to v6.
+Upgrade frontend-platform from v4 to v5.
+
+### Features
+
+* Add .npmrc file to more .gitignore files ([#303](https://github.com/openedx/frontend-enterprise/issues/303)) ([d890c21](https://github.com/openedx/frontend-enterprise/commit/d890c212c3f8c5ec81e6dee63f68029ad0b00552))
+* bumped frontend-platform to v6 ([#364](https://github.com/openedx/frontend-enterprise/issues/364)) ([1541b86](https://github.com/openedx/frontend-enterprise/commit/1541b864dc6c351ea595d9f0c5669299af3b64cc))
+* update react & react-dom to v17 ([#338](https://github.com/openedx/frontend-enterprise/issues/338)) ([b1b548c](https://github.com/openedx/frontend-enterprise/commit/b1b548c0ec27572d639f276507a1495b78db9497))
+* upgrade react router to v6 ([#344](https://github.com/openedx/frontend-enterprise/issues/344)) ([54f6340](https://github.com/openedx/frontend-enterprise/commit/54f6340f764a9120bebd654564e0d61918a3cffa))
+* upgraded to node v18, added .nvmrc and updated workflows ([#306](https://github.com/openedx/frontend-enterprise/issues/306)) ([0508783](https://github.com/openedx/frontend-enterprise/commit/050878307ff5f8a94385b7f41070dec19c7e84cc))
+
+
+### Bug Fixes
+
+* Bump all versions one final time I hope.... ([#297](https://github.com/openedx/frontend-enterprise/issues/297)) ([3452d81](https://github.com/openedx/frontend-enterprise/commit/3452d810bad4b7292ce342ac96bec500809b532d))
+* bump frontend-platform ([#363](https://github.com/openedx/frontend-enterprise/issues/363)) ([1413ef2](https://github.com/openedx/frontend-enterprise/commit/1413ef21a1736d572bddb770352f33d505242bef))
+* manully bump versions after failed automation run ([#301](https://github.com/openedx/frontend-enterprise/issues/301)) ([f1e8616](https://github.com/openedx/frontend-enterprise/commit/f1e8616996c46ffda1c7596be6fc323136ac34c2))
+
+
+### Miscellaneous Chores
+
+* move paragon to peer dependency using [@openedx](https://github.com/openedx) scope and upgrade frontend-platform ([#367](https://github.com/openedx/frontend-enterprise/issues/367)) ([d121d67](https://github.com/openedx/frontend-enterprise/commit/d121d67efa6e84de86a7f3eb84acb674f2d4a380))
+
+
+
 ## [4.1.0](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-logistration@4.0.0...@edx/frontend-enterprise-logistration@4.1.0) (2024-02-01)
 
 

--- a/packages/logistration/package.json
+++ b/packages/logistration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-enterprise-logistration",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "description": "Enterprise-specific component(s) to ensure enterprise users are redirected to branded enterprise logistration flow.",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@edx/frontend-enterprise-utils": "^4.1.0",
+    "@edx/frontend-enterprise-utils": "^5.0.0",
     "prop-types": "15.7.2"
   },
   "devDependencies": {

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -3,6 +3,48 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [5.0.0](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-utils@2.2.0...@edx/frontend-enterprise-utils@5.0.0) (2024-02-12)
+
+
+### ⚠ BREAKING CHANGES
+
+* consuming applications must now provide paragon from the @openedx scope
+
+* refactor: replace @edx/paragon and @edx/frontend-build
+
+* fix: fixed package issues
+
+* fix: updated dependency
+
+* fix: updated package lock file to fix ci issue
+
+* refactor: updated frontend-platform to v7 along with peer Dependencies
+* Upgrade react-router-dom from v5 to v6.
+Upgrade frontend-platform from v4 to v5.
+
+### Features
+
+* Add .npmrc file to more .gitignore files ([#303](https://github.com/openedx/frontend-enterprise/issues/303)) ([d890c21](https://github.com/openedx/frontend-enterprise/commit/d890c212c3f8c5ec81e6dee63f68029ad0b00552))
+* bumped frontend-platform to v6 ([#364](https://github.com/openedx/frontend-enterprise/issues/364)) ([1541b86](https://github.com/openedx/frontend-enterprise/commit/1541b864dc6c351ea595d9f0c5669299af3b64cc))
+* update react & react-dom to v17 ([#338](https://github.com/openedx/frontend-enterprise/issues/338)) ([b1b548c](https://github.com/openedx/frontend-enterprise/commit/b1b548c0ec27572d639f276507a1495b78db9497))
+* upgrade react router to v6 ([#344](https://github.com/openedx/frontend-enterprise/issues/344)) ([54f6340](https://github.com/openedx/frontend-enterprise/commit/54f6340f764a9120bebd654564e0d61918a3cffa))
+* upgraded to node v18, added .nvmrc and updated workflows ([#306](https://github.com/openedx/frontend-enterprise/issues/306)) ([0508783](https://github.com/openedx/frontend-enterprise/commit/050878307ff5f8a94385b7f41070dec19c7e84cc))
+
+
+### Bug Fixes
+
+* Bump all versions one final time I hope.... ([#297](https://github.com/openedx/frontend-enterprise/issues/297)) ([3452d81](https://github.com/openedx/frontend-enterprise/commit/3452d810bad4b7292ce342ac96bec500809b532d))
+* bump frontend-platform ([#363](https://github.com/openedx/frontend-enterprise/issues/363)) ([1413ef2](https://github.com/openedx/frontend-enterprise/commit/1413ef21a1736d572bddb770352f33d505242bef))
+* manully bump versions after failed automation run ([#301](https://github.com/openedx/frontend-enterprise/issues/301)) ([f1e8616](https://github.com/openedx/frontend-enterprise/commit/f1e8616996c46ffda1c7596be6fc323136ac34c2))
+* more version fixes ([#292](https://github.com/openedx/frontend-enterprise/issues/292)) ([f51bafc](https://github.com/openedx/frontend-enterprise/commit/f51bafcb8a93d9f3be40437c16b55ef5c79d7f04))
+
+
+### Miscellaneous Chores
+
+* move paragon to peer dependency using [@openedx](https://github.com/openedx) scope and upgrade frontend-platform ([#367](https://github.com/openedx/frontend-enterprise/issues/367)) ([d121d67](https://github.com/openedx/frontend-enterprise/commit/d121d67efa6e84de86a7f3eb84acb674f2d4a380))
+
+
+
 ## [4.1.0](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-utils@4.0.0...@edx/frontend-enterprise-utils@4.1.0) (2024-02-01)
 
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-enterprise-utils",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "description": "Utils and other miscellaneous enterprise things.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
 - @edx/frontend-enterprise-catalog-search@6.0.0
 - @edx/frontend-enterprise-hotjar@3.0.0
 - @edx/frontend-enterprise-logistration@5.0.0
 - @edx/frontend-enterprise-utils@5.0.0

**Merge checklist:**
- [ ] Evaluate how your changes will impact existing consumers (e.g., `frontend-app-learner-portal-enterprise`, `frontend-app-admin-portal`, and `frontend-app-enterprise-public-catalog`). Will consumers safely be able to upgrade to this change without any breaking changes?
- [ ] Ensure your commit message follows the semantic-release conventional commit message format. If your changes include a breaking change, ensure your commit message is explicitly marked as a `BREAKING CHANGE` so the NPM package is released as such.
- [ ] Once CI is passing, verify the package versions that Lerna will increment to in the Github Action CI workflow logs.
    - *Note*: This may be found in the "Preview Updated Versions (dry run)" step in the Github Action CI workflow logs.

**Post merge:**
- [ ] Verify Lerna created a release commit (e.g., ``chore(release): publish``) that incremented versions in relevant package.json and CHANGELOG files, and created [Git tags](https://github.com/openedx/frontend-enterprise/tags) for those versions.
- [ ] Run the ``Publish from package.json`` Github Action [workflow](https://github.com/openedx/frontend-enterprise/actions/workflows/publish-from-package.yml) to publish these new package versions to NPM.
    - This may be triggered by clicking the "Run workflow" option for the ``master`` branch.
- [ ] Verify the new package versions were published to NPM (i.e., ``npm view <package_name> versions --json``).
    - *Note*: There may be a slight delay between when the workflow finished and when NPM reports the package version as being published. If it doesn't appear right away in the above command, try again in a few minutes.
