### PR TITLE
[ENT-8400] Add subtitle facet to search header

### DIFF
--- a/packages/catalog-search/src/config/index.js
+++ b/packages/catalog-search/src/config/index.js
@@ -5,6 +5,7 @@ export const FEATURE_LANGUAGE_FACET = 'LANGUAGE_FACET';
 export const FEATURE_PROGRAM_TITLES_FACET = 'PROGRAM_TITLES_FACET';
 export const LEARNING_TYPE_FACET = 'LEARNING_TYPE_FACET';
 export const FEATURE_ENABLE_PATHWAYS = 'ENABLE_PATHWAYS';
+export const FEATURE_SUBTITLE_FACET = 'SUBTITLE_FACET';
 
 // eslint-disable-next-line import/prefer-default-export
 export const features = {
@@ -18,5 +19,8 @@ export const features = {
   ),
   ENABlE_PATHWAYS: (
     process.env.FEATURE_ENABLE_PATHWAYS || hasFeatureFlagEnabled(FEATURE_ENABLE_PATHWAYS)
+  ),
+  SUBTITLE_FACET: (
+    process.env.FEATURE_SUBTITLE_FACET || hasFeatureFlagEnabled(FEATURE_SUBTITLE_FACET)
   ),
 };

--- a/packages/catalog-search/src/data/constants.js
+++ b/packages/catalog-search/src/data/constants.js
@@ -73,6 +73,14 @@ if (features.LEARNING_TYPE_FACET) {
   });
 }
 
+if (features.SUBTITLE_FACET) {
+  SEARCH_FACET_FILTERS.push({
+    attribute: 'transcript_languages',
+    title: 'Subtitle',
+    isSortedAlphabetical: true,
+  });
+}
+
 export const BOOLEAN_FILTERS = [SHOW_ALL_NAME];
 export const QUERY_PARAM_FOR_SEARCH_QUERY = 'q';
 export const QUERY_PARAM_FOR_PAGE = 'page';

--- a/packages/catalog-search/src/data/tests/constants.test.js
+++ b/packages/catalog-search/src/data/tests/constants.test.js
@@ -1,0 +1,53 @@
+import {
+  SEARCH_FACET_FILTERS,
+  ADDITIONAL_FACET_FILTERS,
+} from '../constants';
+
+jest.mock('../../config', () => ({
+  __esModule: true,
+  features: {
+    ENROLL_WITH_CODES: true,
+    LANGUAGE_FACET: true,
+    PROGRAM_TITLES_FACET: true,
+    LEARNING_TYPE_FACET: true,
+    ENABLE_PATHWAYS: true,
+    SUBTITLE_FACET: true,
+  },
+}));
+
+describe('Constants', () => {
+  test('Search facet filters are defined correctly', () => {
+    expect(SEARCH_FACET_FILTERS).toHaveLength(9);
+  });
+
+  test('Additional facet filters are defined correctly', () => {
+    expect(Array.isArray(ADDITIONAL_FACET_FILTERS)).toBe(true);
+  });
+
+  test('Language facet filter is added when feature is enabled', () => {
+    const languageFacet = SEARCH_FACET_FILTERS.find(
+      (facet) => facet.attribute === 'language',
+    );
+    expect(languageFacet).toBeDefined();
+    expect(languageFacet.title).toBe('Language');
+    expect(languageFacet.isSortedAlphabetical).toBe(true);
+  });
+
+  test('Learning type facet filter is added when feature is enabled', () => {
+    const learningTypeFacet = SEARCH_FACET_FILTERS.find(
+      (facet) => facet.attribute === 'content_type',
+    );
+    expect(learningTypeFacet).toBeDefined();
+    expect(learningTypeFacet.title).toBe('Learning type');
+    expect(learningTypeFacet.noDisplay).toBe(true);
+  });
+
+  test('Subtitle facet filter is added when feature is enabled', () => {
+    const subtitleFacet = SEARCH_FACET_FILTERS.find(
+      (facet) => facet.attribute === 'transcript_languages',
+    );
+    expect(subtitleFacet).toBeDefined();
+    expect(subtitleFacet.title).toBe('Subtitle');
+    expect(subtitleFacet.isSortedAlphabetical).toBe(true);
+  });
+});


### PR DESCRIPTION
### Description
Adds a "Subtitle" facet dropdown to the search header that corresponds to the `transcript_languages` attribute in Algolia to filter out the courses that have video transcripts associated with them.

### Ticket
[ENT-8400](https://2u-internal.atlassian.net/browse/ENT-8400)


<img width="1440" alt="Screenshot 2024-03-25 at 4 24 22 PM" src="https://github.com/openedx/frontend-enterprise/assets/113524403/25352122-0da1-40c7-99ed-fbb6806beebb">


**Merge checklist:**
- [ ] Evaluate how your changes will impact existing consumers (e.g., `frontend-app-learner-portal-enterprise`, `frontend-app-admin-portal`, and `frontend-app-enterprise-public-catalog`). Will consumers safely be able to upgrade to this change without any breaking changes?
- [ ] Ensure your commit message follows the semantic-release conventional commit message format. If your changes include a breaking change, ensure your commit message is explicitly marked as a `BREAKING CHANGE` so the NPM package is released as such.
- [ ] Once CI is passing, verify the package versions that Lerna will increment to in the Github Action CI workflow logs.
    - *Note*: This may be found in the "Preview Updated Versions (dry run)" step in the Github Action CI workflow logs.

**Post merge:**
- [ ] Verify Lerna created a release commit (e.g., ``chore(release): publish``) that incremented versions in relevant package.json and CHANGELOG files, and created [Git tags](https://github.com/openedx/frontend-enterprise/tags) for those versions.
- [ ] Run the ``Publish from package.json`` Github Action [workflow](https://github.com/openedx/frontend-enterprise/actions/workflows/publish-from-package.yml) to publish these new package versions to NPM.
    - This may be triggered by clicking the "Run workflow" option for the ``master`` branch.
- [ ] Verify the new package versions were published to NPM (i.e., ``npm view <package_name> versions --json``).
    - *Note*: There may be a slight delay between when the workflow finished and when NPM reports the package version as being published. If it doesn't appear right away in the above command, try again in a few minutes.
