### PR TITLE
chore(release): publish new versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28148,10 +28148,10 @@
     },
     "packages/catalog-search": {
       "name": "@edx/frontend-enterprise-catalog-search",
-      "version": "9.0.0",
+      "version": "10.0.0",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@edx/frontend-enterprise-utils": "^8.0.0",
+        "@edx/frontend-enterprise-utils": "^9.0.0",
         "classnames": "2.2.5",
         "lodash.debounce": "4.0.8",
         "prop-types": "15.7.2"
@@ -28182,7 +28182,7 @@
     },
     "packages/hotjar": {
       "name": "@edx/frontend-enterprise-hotjar",
-      "version": "6.0.0",
+      "version": "7.0.0",
       "license": "AGPL-3.0",
       "devDependencies": {
         "@edx/browserslist-config": "1.1.0",
@@ -28199,10 +28199,10 @@
     },
     "packages/logistration": {
       "name": "@edx/frontend-enterprise-logistration",
-      "version": "8.0.0",
+      "version": "9.0.0",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@edx/frontend-enterprise-utils": "^8.0.0",
+        "@edx/frontend-enterprise-utils": "^9.0.0",
         "prop-types": "15.7.2"
       },
       "devDependencies": {
@@ -28225,7 +28225,7 @@
     },
     "packages/utils": {
       "name": "@edx/frontend-enterprise-utils",
-      "version": "8.0.0",
+      "version": "9.0.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@testing-library/react": "12.1.4",

--- a/packages/catalog-search/CHANGELOG.md
+++ b/packages/catalog-search/CHANGELOG.md
@@ -3,6 +3,47 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [10.0.0](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-catalog-search@5.0.0...@edx/frontend-enterprise-catalog-search@10.0.0) (2024-03-29)
+
+
+### ⚠ BREAKING CHANGES
+
+* consuming applications must now provide paragon from the @openedx scope
+
+* refactor: replace @edx/paragon and @edx/frontend-build
+
+* fix: fixed package issues
+
+* fix: updated dependency
+
+* fix: updated package lock file to fix ci issue
+
+* refactor: updated frontend-platform to v7 along with peer Dependencies
+
+### Features
+
+* add prequery search suggestions ([#371](https://github.com/openedx/frontend-enterprise/issues/371)) ([3651ee0](https://github.com/openedx/frontend-enterprise/commit/3651ee0f0e77e461956175d98aaa4addb38a1762))
+* add subtitle facet to SearchHeader ([#382](https://github.com/openedx/frontend-enterprise/issues/382)) ([047844f](https://github.com/openedx/frontend-enterprise/commit/047844fc32df30a09fddcefdc436a951bc821849))
+* added prequery event handler to search ([#373](https://github.com/openedx/frontend-enterprise/issues/373)) ([5705327](https://github.com/openedx/frontend-enterprise/commit/5705327b5aac701cf5288a697071ed48980b9859))
+* allow Paragon v21 in catalog-search ([#356](https://github.com/openedx/frontend-enterprise/issues/356)) ([75005f5](https://github.com/openedx/frontend-enterprise/commit/75005f5e27304e3147fc141ef5dc1bc6ac64a834))
+* bumped frontend-platform to v6 ([#364](https://github.com/openedx/frontend-enterprise/issues/364)) ([1541b86](https://github.com/openedx/frontend-enterprise/commit/1541b864dc6c351ea595d9f0c5669299af3b64cc))
+* enable prequery suggestions only for variant group ([#377](https://github.com/openedx/frontend-enterprise/issues/377)) ([fbee42a](https://github.com/openedx/frontend-enterprise/commit/fbee42a8b2a7a3111a83bf34b1917fc96454ba01))
+* fix prequery suggestion highlight container ([#380](https://github.com/openedx/frontend-enterprise/issues/380)) ([d54a0c7](https://github.com/openedx/frontend-enterprise/commit/d54a0c765def9850e37296e3fd8d7709664d08b4))
+* removing free/all filter ([#359](https://github.com/openedx/frontend-enterprise/issues/359)) ([f187fbd](https://github.com/openedx/frontend-enterprise/commit/f187fbd89eb8c6b490b8a0fafb7f192ed9dcf24c))
+
+
+### Bug Fixes
+
+* bump frontend-platform ([#363](https://github.com/openedx/frontend-enterprise/issues/363)) ([1413ef2](https://github.com/openedx/frontend-enterprise/commit/1413ef21a1736d572bddb770352f33d505242bef))
+* remove pathways from customers search ([#366](https://github.com/openedx/frontend-enterprise/issues/366)) ([d4625c9](https://github.com/openedx/frontend-enterprise/commit/d4625c92443d088c2319f81ea516c2613b8d3943))
+
+
+### Miscellaneous Chores
+
+* move paragon to peer dependency using [@openedx](https://github.com/openedx) scope and upgrade frontend-platform ([#367](https://github.com/openedx/frontend-enterprise/issues/367)) ([d121d67](https://github.com/openedx/frontend-enterprise/commit/d121d67efa6e84de86a7f3eb84acb674f2d4a380))
+
+
+
 ## [9.0.0](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-catalog-search@5.0.0...@edx/frontend-enterprise-catalog-search@9.0.0) (2024-03-11)
 
 

--- a/packages/catalog-search/package.json
+++ b/packages/catalog-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-enterprise-catalog-search",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Components related to Enterprise catalog search.",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@edx/frontend-enterprise-utils": "^8.0.0",
+    "@edx/frontend-enterprise-utils": "^9.0.0",
     "classnames": "2.2.5",
     "lodash.debounce": "4.0.8",
     "prop-types": "15.7.2"

--- a/packages/hotjar/CHANGELOG.md
+++ b/packages/hotjar/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [7.0.0](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-hotjar@2.0.0...@edx/frontend-enterprise-hotjar@7.0.0) (2024-03-29)
+
+
+### ⚠ BREAKING CHANGES
+
+* consuming applications must now provide paragon from the @openedx scope
+
+* refactor: replace @edx/paragon and @edx/frontend-build
+
+* fix: fixed package issues
+
+* fix: updated dependency
+
+* fix: updated package lock file to fix ci issue
+
+* refactor: updated frontend-platform to v7 along with peer Dependencies
+
+### Miscellaneous Chores
+
+* move paragon to peer dependency using [@openedx](https://github.com/openedx) scope and upgrade frontend-platform ([#367](https://github.com/openedx/frontend-enterprise/issues/367)) ([d121d67](https://github.com/openedx/frontend-enterprise/commit/d121d67efa6e84de86a7f3eb84acb674f2d4a380))
+
+
+
 ## [6.0.0](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-hotjar@2.0.0...@edx/frontend-enterprise-hotjar@6.0.0) (2024-03-11)
 
 

--- a/packages/hotjar/package.json
+++ b/packages/hotjar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-enterprise-hotjar",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "Utils for Hotjar.",
   "repository": {
     "type": "git",

--- a/packages/logistration/CHANGELOG.md
+++ b/packages/logistration/CHANGELOG.md
@@ -3,6 +3,39 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [9.0.0](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-logistration@4.0.0...@edx/frontend-enterprise-logistration@9.0.0) (2024-03-29)
+
+
+### ⚠ BREAKING CHANGES
+
+* consuming applications must now provide paragon from the @openedx scope
+
+* refactor: replace @edx/paragon and @edx/frontend-build
+
+* fix: fixed package issues
+
+* fix: updated dependency
+
+* fix: updated package lock file to fix ci issue
+
+* refactor: updated frontend-platform to v7 along with peer Dependencies
+
+### Features
+
+* bumped frontend-platform to v6 ([#364](https://github.com/openedx/frontend-enterprise/issues/364)) ([1541b86](https://github.com/openedx/frontend-enterprise/commit/1541b864dc6c351ea595d9f0c5669299af3b64cc))
+
+
+### Bug Fixes
+
+* bump frontend-platform ([#363](https://github.com/openedx/frontend-enterprise/issues/363)) ([1413ef2](https://github.com/openedx/frontend-enterprise/commit/1413ef21a1736d572bddb770352f33d505242bef))
+
+
+### Miscellaneous Chores
+
+* move paragon to peer dependency using [@openedx](https://github.com/openedx) scope and upgrade frontend-platform ([#367](https://github.com/openedx/frontend-enterprise/issues/367)) ([d121d67](https://github.com/openedx/frontend-enterprise/commit/d121d67efa6e84de86a7f3eb84acb674f2d4a380))
+
+
+
 ## [8.0.0](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-logistration@4.0.0...@edx/frontend-enterprise-logistration@8.0.0) (2024-03-11)
 
 

--- a/packages/logistration/package.json
+++ b/packages/logistration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-enterprise-logistration",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "description": "Enterprise-specific component(s) to ensure enterprise users are redirected to branded enterprise logistration flow.",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@edx/frontend-enterprise-utils": "^8.0.0",
+    "@edx/frontend-enterprise-utils": "^9.0.0",
     "prop-types": "15.7.2"
   },
   "devDependencies": {

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -3,6 +3,39 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [9.0.0](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-utils@4.0.0...@edx/frontend-enterprise-utils@9.0.0) (2024-03-29)
+
+
+### ⚠ BREAKING CHANGES
+
+* consuming applications must now provide paragon from the @openedx scope
+
+* refactor: replace @edx/paragon and @edx/frontend-build
+
+* fix: fixed package issues
+
+* fix: updated dependency
+
+* fix: updated package lock file to fix ci issue
+
+* refactor: updated frontend-platform to v7 along with peer Dependencies
+
+### Features
+
+* bumped frontend-platform to v6 ([#364](https://github.com/openedx/frontend-enterprise/issues/364)) ([1541b86](https://github.com/openedx/frontend-enterprise/commit/1541b864dc6c351ea595d9f0c5669299af3b64cc))
+
+
+### Bug Fixes
+
+* bump frontend-platform ([#363](https://github.com/openedx/frontend-enterprise/issues/363)) ([1413ef2](https://github.com/openedx/frontend-enterprise/commit/1413ef21a1736d572bddb770352f33d505242bef))
+
+
+### Miscellaneous Chores
+
+* move paragon to peer dependency using [@openedx](https://github.com/openedx) scope and upgrade frontend-platform ([#367](https://github.com/openedx/frontend-enterprise/issues/367)) ([d121d67](https://github.com/openedx/frontend-enterprise/commit/d121d67efa6e84de86a7f3eb84acb674f2d4a380))
+
+
+
 ## [8.0.0](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-utils@4.0.0...@edx/frontend-enterprise-utils@8.0.0) (2024-03-11)
 
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-enterprise-utils",
-  "version": "8.0.0",
+  "version": "9.0.0",
   "description": "Utils and other miscellaneous enterprise things.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
 - @edx/frontend-enterprise-catalog-search@10.0.0
 - @edx/frontend-enterprise-hotjar@7.0.0
 - @edx/frontend-enterprise-logistration@9.0.0
 - @edx/frontend-enterprise-utils@9.0.0

**Merge checklist:**
- [ ] Evaluate how your changes will impact existing consumers (e.g., `frontend-app-learner-portal-enterprise`, `frontend-app-admin-portal`, and `frontend-app-enterprise-public-catalog`). Will consumers safely be able to upgrade to this change without any breaking changes?
- [ ] Ensure your commit message follows the semantic-release conventional commit message format. If your changes include a breaking change, ensure your commit message is explicitly marked as a `BREAKING CHANGE` so the NPM package is released as such.
- [ ] Once CI is passing, verify the package versions that Lerna will increment to in the Github Action CI workflow logs.
    - *Note*: This may be found in the "Preview Updated Versions (dry run)" step in the Github Action CI workflow logs.

**Post merge:**
- [x] Verify Lerna created a release commit (e.g., ``chore(release): publish``) that incremented versions in relevant package.json and CHANGELOG files, and created [Git tags](https://github.com/openedx/frontend-enterprise/tags) for those versions.
- [ ] Run the ``Publish from package.json`` Github Action [workflow](https://github.com/openedx/frontend-enterprise/actions/workflows/publish-from-package.yml) to publish these new package versions to NPM.
    - This may be triggered by clicking the "Run workflow" option for the ``master`` branch.
- [ ] Verify the new package versions were published to NPM (i.e., ``npm view <package_name> versions --json``).
    - *Note*: There may be a slight delay between when the workflow finished and when NPM reports the package version as being published. If it doesn't appear right away in the above command, try again in a few minutes.
