### PR TITLE
chore: clean up ignoreChanges lerna config

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -12,15 +12,11 @@
     }
   },
   "ignoreChanges": [
-    "CHANGELOG.md",
-    "node_modules/**",
-    "package.json",
     "*.md",
-    "perf/**",
+    "*.rst",
     ".github/**",
-    "packages/**/.eslintrc.js",
-    "packages/**/.gitignore",
-    "packages/**/*.rst"
+    ".eslintrc.js",
+    ".gitignore"
   ],
   "changelogPreset": {
     "name": "conventionalcommits",


### PR DESCRIPTION
After re-creating the most recent Git tags to be associated with the `master` branch and the expected commit SHA, the `lerna version` command is not detecting changes for the most recent merged commit on `master`. The most recent commit updates package.json and package-lock.json versions, however, the `ignoreChanges` configuration in `lerna.json` included `package.json`, which prevents Lerna from detecting the most recent merged commit as a new change needing a version bump.

```shell
lerna info Looking for changed packages since @edx/frontend-enterprise-catalog-search@10.0.0
lerna info ignoring diff in paths matching [
lerna info ignoring diff in paths matching   'CHANGELOG.md',
lerna info ignoring diff in paths matching   'node_modules/**',
lerna info ignoring diff in paths matching   'package.json',
lerna info ignoring diff in paths matching   '*.md',
lerna info ignoring diff in paths matching   'perf/**',
lerna info ignoring diff in paths matching   '.github/**',
lerna info ignoring diff in paths matching   'packages/**/.eslintrc.js',
lerna info ignoring diff in paths matching   'packages/**/.gitignore',
lerna info ignoring diff in paths matching   'packages/**/*.rst'
lerna info ignoring diff in paths matching ]
lerna verb no diff found in @edx/frontend-enterprise-catalog-search (after filtering)
lerna verb no diff found in @edx/frontend-enterprise-hotjar (after filtering)
lerna verb no diff found in @edx/frontend-enterprise-logistration (after filtering)
lerna verb no diff found in @edx/frontend-enterprise-utils (after filtering)
lerna success No changed packages to version 
```

By removing the `package.json` from the `ignoreChanges` Lerna configuration, and re-running `npm run lerna:version`, Lerna now properly detects changes from the most recent merged commit on `master` (various package.json version bumps), and previews the expected next version increments based on the semantic commit types since the last release (e.g., `@edx/frontend-enterprise-catalog-search: 10.0.0 => 10.1.0`).

**We will still need to verify and update documentation on how to ensure generated Git tags are included on the `master` branch so lerna stays aware of new tags as they are created.**

**Merge checklist:**
- [ ] Evaluate how your changes will impact existing consumers (e.g., `frontend-app-learner-portal-enterprise`, `frontend-app-admin-portal`, and `frontend-app-enterprise-public-catalog`). Will consumers safely be able to upgrade to this change without any breaking changes?
- [ ] Ensure your commit message follows the semantic-release conventional commit message format. If your changes include a breaking change, ensure your commit message is explicitly marked as a `BREAKING CHANGE` so the NPM package is released as such.
- [ ] Once CI is passing, verify the package versions that Lerna will increment to in the Github Action CI workflow logs.
    - *Note*: This may be found in the "Preview Updated Versions (dry run)" step in the Github Action CI workflow logs.

**Post merge:**
- [ ] Verify Lerna created a release commit (e.g., ``chore(release): publish``) that incremented versions in relevant package.json and CHANGELOG files, and created [Git tags](https://github.com/openedx/frontend-enterprise/tags) for those versions.
- [ ] Run the ``Publish from package.json`` Github Action [workflow](https://github.com/openedx/frontend-enterprise/actions/workflows/publish-from-package.yml) to publish these new package versions to NPM.
    - This may be triggered by clicking the "Run workflow" option for the ``master`` branch.
- [ ] Verify the new package versions were published to NPM (i.e., ``npm view <package_name> versions --json``).
    - *Note*: There may be a slight delay between when the workflow finished and when NPM reports the package version as being published. If it doesn't appear right away in the above command, try again in a few minutes.
