### PR TITLE
chore(release): publish new versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26239,10 +26239,10 @@
     },
     "packages/catalog-search": {
       "name": "@edx/frontend-enterprise-catalog-search",
-      "version": "10.0.0",
+      "version": "10.1.0",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@edx/frontend-enterprise-utils": "^9.0.0",
+        "@edx/frontend-enterprise-utils": "^9.1.0",
         "classnames": "2.2.5",
         "lodash.debounce": "4.0.8",
         "prop-types": "15.7.2"
@@ -26273,7 +26273,7 @@
     },
     "packages/hotjar": {
       "name": "@edx/frontend-enterprise-hotjar",
-      "version": "7.0.0",
+      "version": "7.1.0",
       "license": "AGPL-3.0",
       "devDependencies": {
         "@edx/browserslist-config": "1.1.0",
@@ -26290,10 +26290,10 @@
     },
     "packages/logistration": {
       "name": "@edx/frontend-enterprise-logistration",
-      "version": "9.0.0",
+      "version": "9.1.0",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@edx/frontend-enterprise-utils": "^9.0.0",
+        "@edx/frontend-enterprise-utils": "^9.1.0",
         "prop-types": "15.7.2"
       },
       "devDependencies": {
@@ -26316,7 +26316,7 @@
     },
     "packages/utils": {
       "name": "@edx/frontend-enterprise-utils",
-      "version": "9.0.0",
+      "version": "9.1.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@testing-library/react": "12.1.4",

--- a/packages/catalog-search/CHANGELOG.md
+++ b/packages/catalog-search/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [10.1.0](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-catalog-search@10.0.0...@edx/frontend-enterprise-catalog-search@10.1.0) (2024-04-29)
+
+
+### Features
+
+* updated frontend-build & frontend-platform major versions ([#387](https://github.com/openedx/frontend-enterprise/issues/387)) ([e9da78e](https://github.com/openedx/frontend-enterprise/commit/e9da78e264c6e5b590eff351b5c1477c0716f928))
+
+
+
 ## [10.0.0](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-catalog-search@5.0.0...@edx/frontend-enterprise-catalog-search@10.0.0) (2024-03-29)
 
 

--- a/packages/catalog-search/package.json
+++ b/packages/catalog-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-enterprise-catalog-search",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "description": "Components related to Enterprise catalog search.",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@edx/frontend-enterprise-utils": "^9.0.0",
+    "@edx/frontend-enterprise-utils": "^9.1.0",
     "classnames": "2.2.5",
     "lodash.debounce": "4.0.8",
     "prop-types": "15.7.2"

--- a/packages/hotjar/CHANGELOG.md
+++ b/packages/hotjar/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [7.1.0](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-hotjar@7.0.0...@edx/frontend-enterprise-hotjar@7.1.0) (2024-04-29)
+
+
+### Features
+
+* updated frontend-build & frontend-platform major versions ([#387](https://github.com/openedx/frontend-enterprise/issues/387)) ([e9da78e](https://github.com/openedx/frontend-enterprise/commit/e9da78e264c6e5b590eff351b5c1477c0716f928))
+
+
+
 ## [7.0.0](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-hotjar@2.0.0...@edx/frontend-enterprise-hotjar@7.0.0) (2024-03-29)
 
 

--- a/packages/hotjar/package.json
+++ b/packages/hotjar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-enterprise-hotjar",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Utils for Hotjar.",
   "repository": {
     "type": "git",

--- a/packages/logistration/CHANGELOG.md
+++ b/packages/logistration/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [9.1.0](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-logistration@9.0.0...@edx/frontend-enterprise-logistration@9.1.0) (2024-04-29)
+
+
+### Features
+
+* updated frontend-build & frontend-platform major versions ([#387](https://github.com/openedx/frontend-enterprise/issues/387)) ([e9da78e](https://github.com/openedx/frontend-enterprise/commit/e9da78e264c6e5b590eff351b5c1477c0716f928))
+
+
+
 ## [9.0.0](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-logistration@4.0.0...@edx/frontend-enterprise-logistration@9.0.0) (2024-03-29)
 
 

--- a/packages/logistration/package.json
+++ b/packages/logistration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-enterprise-logistration",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "Enterprise-specific component(s) to ensure enterprise users are redirected to branded enterprise logistration flow.",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@edx/frontend-enterprise-utils": "^9.0.0",
+    "@edx/frontend-enterprise-utils": "^9.1.0",
     "prop-types": "15.7.2"
   },
   "devDependencies": {

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [9.1.0](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-utils@9.0.0...@edx/frontend-enterprise-utils@9.1.0) (2024-04-29)
+
+
+### Features
+
+* updated frontend-build & frontend-platform major versions ([#387](https://github.com/openedx/frontend-enterprise/issues/387)) ([e9da78e](https://github.com/openedx/frontend-enterprise/commit/e9da78e264c6e5b590eff351b5c1477c0716f928))
+
+
+
 ## [9.0.0](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-utils@4.0.0...@edx/frontend-enterprise-utils@9.0.0) (2024-03-29)
 
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-enterprise-utils",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "description": "Utils and other miscellaneous enterprise things.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
 - @edx/frontend-enterprise-catalog-search@10.1.0
 - @edx/frontend-enterprise-hotjar@7.1.0
 - @edx/frontend-enterprise-logistration@9.1.0
 - @edx/frontend-enterprise-utils@9.1.0

**Merge checklist:**
- [ ] Evaluate how your changes will impact existing consumers (e.g., `frontend-app-learner-portal-enterprise`, `frontend-app-admin-portal`, and `frontend-app-enterprise-public-catalog`). Will consumers safely be able to upgrade to this change without any breaking changes?
- [ ] Ensure your commit message follows the semantic-release conventional commit message format. If your changes include a breaking change, ensure your commit message is explicitly marked as a `BREAKING CHANGE` so the NPM package is released as such.
- [ ] Once CI is passing, verify the package versions that Lerna will increment to in the Github Action CI workflow logs.
    - *Note*: This may be found in the "Preview Updated Versions (dry run)" step in the Github Action CI workflow logs.

**Post merge:**
- [ ] Verify Lerna created a release commit (e.g., ``chore(release): publish``) that incremented versions in relevant package.json and CHANGELOG files, and created [Git tags](https://github.com/openedx/frontend-enterprise/tags) for those versions.
- [ ] Run the ``Publish from package.json`` Github Action [workflow](https://github.com/openedx/frontend-enterprise/actions/workflows/publish-from-package.yml) to publish these new package versions to NPM.
    - This may be triggered by clicking the "Run workflow" option for the ``master`` branch.
- [ ] Verify the new package versions were published to NPM (i.e., ``npm view <package_name> versions --json``).
    - *Note*: There may be a slight delay between when the workflow finished and when NPM reports the package version as being published. If it doesn't appear right away in the above command, try again in a few minutes.
