### PR TITLE
docs: minor updates to README release steps

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,11 +111,11 @@ Note: only `fix`, `feat`, and `perf` will trigger a new NPM release, as this is 
 Versioning and releases
 ***********************
 
-This library has its version automatically updated by Lerna (i.e., ``lerna version``) using semantic-versioning under-the-hood when the release is published to npm. Lerna is configured to use independent versioning with conventional commits, as opposed to keeping all package versions in sync.
+This library has its version automatically updated by Lerna using semantic versioning under-the-hood when the release is published to NPM. Lerna is configured to use independent versioning with conventional commits, as opposed to keeping all package versions in sync.
 
-When a PR is merged, you must manually run ``lerna version`` to create a release commit (e.g., ``chore(release): publish new versions``). In this commit, Lerna increments the versions in the appropriate package.json files for any changed packages, creates Git tags, and updates the CHANGELOG file(s).
+When your contribution's PR is approved/merged, you'll need to instruct Lerna to create a new release commit (i.e., ``chore(release): publish new versions``), as outlined in the steps below. In this release commit, Lerna increments the versions in the appropriate package.json files for any changed packages, creates Git tags, and updates the CHANGELOG file(s).
 
-Once your contribution's PR is approved/merged:
+To create the Lerna release commit once your contribution's PR is approved/merged, please perform the following steps:
 
 #. Pull latest changes on your local checkout of ``master``, ensuring your merged commit is included. It's also recommended to ensure you have the latest Git tags (i.e., ``git fetch --tags``).
 #. Checkout a new branch and execute ``npm run lerna:version``. Verify the recognized changed packages and their associated versions are correct. Once confirmed, Lerna will create a release commit and Git tags.

--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,7 @@ Note: only `fix`, `feat`, and `perf` will trigger a new NPM release, as this is 
 Versioning and releases
 ***********************
 
-This library has its version automatically updated by Lerna using semantic versioning under-the-hood when the release is published to NPM. Lerna is configured to use independent versioning with conventional commits, as opposed to keeping all package versions in sync.
+This library has its version automatically updated by Lerna using semantic versioning under-the-hood when publishing to NPM. Lerna is configured to use independent versioning with conventional commits, as opposed to keeping all package versions in sync.
 
 When your contribution's PR is approved/merged, you'll need to instruct Lerna to create a new release commit (i.e., ``chore(release): publish new versions``), as outlined in the steps below. In this release commit, Lerna increments the versions in the appropriate package.json files for any changed packages, creates Git tags, and updates the CHANGELOG file(s).
 


### PR DESCRIPTION
**Merge checklist:**
- [ ] Evaluate how your changes will impact existing consumers (e.g., `frontend-app-learner-portal-enterprise`, `frontend-app-admin-portal`, and `frontend-app-enterprise-public-catalog`). Will consumers safely be able to upgrade to this change without any breaking changes?
- [ ] Ensure your commit message follows the semantic-release conventional commit message format. If your changes include a breaking change, ensure your commit message is explicitly marked as a `BREAKING CHANGE` so the NPM package is released as such.
- [ ] Once CI is passing, verify the package versions that Lerna will increment to in the Github Action CI workflow logs.
    - *Note*: This may be found in the "Preview Updated Versions (dry run)" step in the Github Action CI workflow logs.

**Post merge:**
- [ ] Follow the [release steps in the README documentation](../README.rst#versioning-and-releases). Verify Lerna's release commit (e.g., ``chore(release): publish new versions``) that incremented versions in relevant package.json and CHANGELOG files, and created [Git tags](https://github.com/openedx/frontend-enterprise/tags) for those versions is on ``master`` (**Important: ensure the Git tags are for the correct commit SHA**).
- [ ] Run the ``Publish from package.json`` Github Action [workflow](https://github.com/openedx/frontend-enterprise/actions/workflows/publish-from-package.yml) to publish these new package versions to NPM.
    - This may be triggered by clicking the "Run workflow" option for the ``master`` branch.
- [ ] Verify the new package versions were published to NPM (i.e., ``npm view <package_name> versions --json``).
    - *Note*: There may be a slight delay between when the workflow finished and when NPM reports the package version as being published. If it doesn't appear right away in the above command, try again in a few minutes.
