### PR TITLE
feat: support React 18 in `@edx/frontend-enterprise-logistration`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,6 @@ jobs:
         with:
           # pulls all commits (needed for lerna / semantic release to correctly version)
           fetch-depth: 0
-      - name: Setup Nodejs Env
-        run: echo "NODE_VER=`cat .nvmrc`" >> $GITHUB_ENV
       # pulls all tags (needed for lerna / semantic release to correctly version)
       - name: Pull All Git Tags
         run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
@@ -21,7 +19,7 @@ jobs:
       - name: Setup Nodejs
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.NODE_VER }}
+          node-version-file: '.nvmrc'
       # lerna expects to be authenticated for publishing to NPM. This step will fail CI if NPM is not authenticated
       - name: Check NPM authentication
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -5754,7 +5754,6 @@
       "version": "10.4.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -5773,7 +5772,6 @@
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5785,7 +5783,6 @@
       "version": "27.5.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -5798,8 +5795,7 @@
     "node_modules/@testing-library/dom/node_modules/react-is": {
       "version": "17.0.2",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "5.17.0",
@@ -24909,24 +24905,117 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@edx/frontend-enterprise-utils": "^9.1.1",
-        "prop-types": "15.8.1"
+        "prop-types": "^15.8.1"
       },
       "devDependencies": {
-        "@edx/browserslist-config": "1.5.0",
-        "@edx/frontend-platform": "8.2.1",
-        "@openedx/frontend-build": "14.3.1",
-        "@testing-library/jest-dom": "5.17.0",
-        "@testing-library/react": "12.1.5",
-        "react": "17.0.2",
-        "react-dom": "17.0.2",
-        "react-router-dom": "6.29.0",
-        "react-test-renderer": "17.0.2"
+        "@edx/browserslist-config": "^1.5.0",
+        "@edx/frontend-platform": "^8.2.1",
+        "@openedx/frontend-build": "^14.3.1",
+        "@testing-library/dom": "^10.4.0",
+        "@testing-library/jest-dom": "^5.17.0",
+        "@testing-library/react": "^16.2.0",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^6.29.0",
+        "react-test-renderer": "^18.3.1"
       },
       "peerDependencies": {
         "@edx/frontend-platform": "^7.0.0 || ^8.0.0",
-        "react": "^16.12.0 || ^17.0.0",
-        "react-dom": "^16.12.0 || ^17.0.0",
+        "react": "^16.12.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.12.0 || ^17.0.0 || ^18.0.0",
         "react-router-dom": "^6.0.0"
+      }
+    },
+    "packages/logistration/node_modules/@testing-library/react": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.2.0.tgz",
+      "integrity": "sha512-2cSskAvA1QNtKc8Y9VJQRv0tm3hLVgxRGDB+KYhIaPQJ1I+RHbhIXcM+zClKXzMes/wshsMVzf4B9vS4IZpqDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "packages/logistration/node_modules/@types/react": {
+      "version": "19.0.10",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.10.tgz",
+      "integrity": "sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
+    "packages/logistration/node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "packages/logistration/node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "packages/logistration/node_modules/react-test-renderer": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.3.1.tgz",
+      "integrity": "sha512-KkAgygexHUkQqtvvx/otwxtuFu5cVjfzTCtjXLH9boS19/Nbtg84zS7wIQn39G8IlrhThBpQsMKkq5ZHZIYFXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^18.3.1",
+        "react-shallow-renderer": "^16.15.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "packages/logistration/node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
       }
     },
     "packages/utils": {

--- a/packages/logistration/package.json
+++ b/packages/logistration/package.json
@@ -38,23 +38,24 @@
   "sideEffects": false,
   "dependencies": {
     "@edx/frontend-enterprise-utils": "^9.1.1",
-    "prop-types": "15.8.1"
+    "prop-types": "^15.8.1"
   },
   "devDependencies": {
-    "@edx/browserslist-config": "1.5.0",
-    "@edx/frontend-platform": "8.2.1",
-    "@openedx/frontend-build": "14.3.1",
-    "@testing-library/jest-dom": "5.17.0",
-    "@testing-library/react": "12.1.5",
-    "react": "17.0.2",
-    "react-dom": "17.0.2",
-    "react-router-dom": "6.29.0",
-    "react-test-renderer": "17.0.2"
+    "@edx/browserslist-config": "^1.5.0",
+    "@edx/frontend-platform": "^8.2.1",
+    "@openedx/frontend-build": "^14.3.1",
+    "@testing-library/jest-dom": "^5.17.0",
+    "@testing-library/react": "^16.2.0",
+    "@testing-library/dom": "^10.4.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.29.0",
+    "react-test-renderer": "^18.3.1"
   },
   "peerDependencies": {
     "@edx/frontend-platform": "^7.0.0 || ^8.0.0",
-    "react": "^16.12.0 || ^17.0.0",
-    "react-dom": "^16.12.0 || ^17.0.0",
+    "react": "^16.12.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.12.0 || ^17.0.0 || ^18.0.0",
     "react-router-dom": "^6.0.0"
   }
 }


### PR DESCRIPTION
**Merge checklist:**
- [ ] Evaluate how your changes will impact existing consumers (e.g., `frontend-app-learner-portal-enterprise`, `frontend-app-admin-portal`, and `frontend-app-enterprise-public-catalog`). Will consumers safely be able to upgrade to this change without any breaking changes?
- [ ] Ensure your commit message follows the semantic-release conventional commit message format. If your changes include a breaking change, ensure your commit message is explicitly marked as a `BREAKING CHANGE` so the NPM package is released as such.
- [ ] Once CI is passing, verify the package versions that Lerna will increment to in the Github Action CI workflow logs.
    - *Note*: This may be found in the "Preview Updated Versions (dry run)" step in the Github Action CI workflow logs.

**Post merge:**
- [ ] Follow the [release steps in the README documentation](../README.rst#versioning-and-releases). Verify Lerna's release commit (e.g., ``chore(release): publish new versions``) that incremented versions in relevant package.json and CHANGELOG files, and created [Git tags](https://github.com/openedx/frontend-enterprise/tags) for those versions is on ``master`` (**Important: ensure the Git tags are for the correct commit SHA**).
- [ ] Run the ``Publish from package.json`` Github Action [workflow](https://github.com/openedx/frontend-enterprise/actions/workflows/publish-from-package.yml) to publish these new package versions to NPM.
    - This may be triggered by clicking the "Run workflow" option for the ``master`` branch.
- [ ] Verify the new package versions were published to NPM (i.e., ``npm view <package_name> versions --json``).
    - *Note*: There may be a slight delay between when the workflow finished and when NPM reports the package version as being published. If it doesn't appear right away in the above command, try again in a few minutes.
