### PR TITLE
chore(release): publish new versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24900,10 +24900,10 @@
     },
     "packages/catalog-search": {
       "name": "@edx/frontend-enterprise-catalog-search",
-      "version": "10.8.1",
+      "version": "10.8.2",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@edx/frontend-enterprise-utils": "^9.1.1",
+        "@edx/frontend-enterprise-utils": "^10.0.0",
         "classnames": "2.5.1",
         "lodash.debounce": "4.0.8",
         "prop-types": "15.8.1"
@@ -24988,10 +24988,10 @@
     },
     "packages/logistration": {
       "name": "@edx/frontend-enterprise-logistration",
-      "version": "9.2.0",
+      "version": "9.2.1",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@edx/frontend-enterprise-utils": "^9.1.1",
+        "@edx/frontend-enterprise-utils": "^10.0.0",
         "prop-types": "^15.8.1"
       },
       "devDependencies": {
@@ -25107,7 +25107,7 @@
     },
     "packages/utils": {
       "name": "@edx/frontend-enterprise-utils",
-      "version": "9.1.1",
+      "version": "10.0.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "history": "^4.10.1"

--- a/packages/catalog-search/CHANGELOG.md
+++ b/packages/catalog-search/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [10.8.2](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-catalog-search@10.8.1...@edx/frontend-enterprise-catalog-search@10.8.2) (2025-02-26)
+
+**Note:** Version bump only for package @edx/frontend-enterprise-catalog-search
+
+
+
+
+
 ## [10.8.1](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-catalog-search@10.8.0...@edx/frontend-enterprise-catalog-search@10.8.1) (2025-02-24)
 
 

--- a/packages/catalog-search/package.json
+++ b/packages/catalog-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-enterprise-catalog-search",
-  "version": "10.8.1",
+  "version": "10.8.2",
   "description": "Components related to Enterprise catalog search.",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@edx/frontend-enterprise-utils": "^9.1.1",
+    "@edx/frontend-enterprise-utils": "^10.0.0",
     "classnames": "2.5.1",
     "lodash.debounce": "4.0.8",
     "prop-types": "15.8.1"

--- a/packages/logistration/CHANGELOG.md
+++ b/packages/logistration/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [9.2.1](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-logistration@9.2.0...@edx/frontend-enterprise-logistration@9.2.1) (2025-02-26)
+
+**Note:** Version bump only for package @edx/frontend-enterprise-logistration
+
+
+
+
+
 ## [9.2.0](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-logistration@9.1.1...@edx/frontend-enterprise-logistration@9.2.0) (2025-02-25)
 
 

--- a/packages/logistration/package.json
+++ b/packages/logistration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-enterprise-logistration",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Enterprise-specific component(s) to ensure enterprise users are redirected to branded enterprise logistration flow.",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@edx/frontend-enterprise-utils": "^9.1.1",
+    "@edx/frontend-enterprise-utils": "^10.0.0",
     "prop-types": "^15.8.1"
   },
   "devDependencies": {

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [10.0.0](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-utils@9.1.1...@edx/frontend-enterprise-utils@10.0.0) (2025-02-26)
+
+
+### ⚠ BREAKING CHANGES
+
+* Requires @testing-library/react as a peer dependency (>11.0.0 <17.0.0)
+feat: support React 18
+
+### Features
+
+* support react 18 and move RTL to peerDep vs regular dep ([#439](https://github.com/openedx/frontend-enterprise/issues/439)) ([ee48b25](https://github.com/openedx/frontend-enterprise/commit/ee48b25431ef3b2432b817e7664938054612dc82))
+
+
+
 ## [9.1.1](https://github.com/openedx/frontend-enterprise/compare/@edx/frontend-enterprise-utils@9.1.0...@edx/frontend-enterprise-utils@9.1.1) (2025-02-24)
 
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-enterprise-utils",
-  "version": "9.1.1",
+  "version": "10.0.0",
   "description": "Utils and other miscellaneous enterprise things.",
   "repository": {
     "type": "git",
@@ -43,8 +43,8 @@
     "@edx/browserslist-config": "^1.5.0",
     "@edx/frontend-platform": "^8.2.1",
     "@openedx/frontend-build": "^14.3.1",
-    "@testing-library/react": "^16.2.0",
     "@testing-library/dom": "^10.4.0",
+    "@testing-library/react": "^16.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.29.0",


### PR DESCRIPTION
 - @edx/frontend-enterprise-catalog-search@10.8.2
 - @edx/frontend-enterprise-logistration@9.2.1
 - @edx/frontend-enterprise-utils@10.0.0

**Merge checklist:**
- [ ] Evaluate how your changes will impact existing consumers (e.g., `frontend-app-learner-portal-enterprise`, `frontend-app-admin-portal`, and `frontend-app-enterprise-public-catalog`). Will consumers safely be able to upgrade to this change without any breaking changes?
- [ ] Ensure your commit message follows the semantic-release conventional commit message format. If your changes include a breaking change, ensure your commit message is explicitly marked as a `BREAKING CHANGE` so the NPM package is released as such.
- [ ] Once CI is passing, verify the package versions that Lerna will increment to in the Github Action CI workflow logs.
    - *Note*: This may be found in the "Preview Updated Versions (dry run)" step in the Github Action CI workflow logs.

**Post merge:**
- [ ] Follow the [release steps in the README documentation](../README.rst#versioning-and-releases). Verify Lerna's release commit (e.g., ``chore(release): publish new versions``) that incremented versions in relevant package.json and CHANGELOG files, and created [Git tags](https://github.com/openedx/frontend-enterprise/tags) for those versions is on ``master`` (**Important: ensure the Git tags are for the correct commit SHA**).
- [ ] Run the ``Publish from package.json`` Github Action [workflow](https://github.com/openedx/frontend-enterprise/actions/workflows/publish-from-package.yml) to publish these new package versions to NPM.
    - This may be triggered by clicking the "Run workflow" option for the ``master`` branch.
- [ ] Verify the new package versions were published to NPM (i.e., ``npm view <package_name> versions --json``).
    - *Note*: There may be a slight delay between when the workflow finished and when NPM reports the package version as being published. If it doesn't appear right away in the above command, try again in a few minutes.
