### PR TITLE
fix: include only content type program and course in search suggestions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,13 @@ jobs:
         npm whoami
     - name: Install and Setup Dependencies
       run: npm ci
-    # build must come before running linting and tests for the `dist` directory to exist.
-    - name: Build
-      run: npm run build
     - name: Lint
       run: npm run lint
     - name: Test
       run: npm run test
+    # switched build step to run after lint and test to fix failing lint errors
+    - name: Build
+      run: npm run build
     - name: "[Lerna] Preview Updated Versions (dry run)"
       # switch from detatched head to a real branch so we can pass it to `--allow-branch`
       run: |

--- a/packages/catalog-search/src/SearchHeader.jsx
+++ b/packages/catalog-search/src/SearchHeader.jsx
@@ -34,6 +34,12 @@ const SearchHeader = ({
     searchQueryFromRefinements = refinements.q;
   }
 
+  // Add filter to only include course and program content_types
+  // as we are currently not supporting videos and pathways
+  const modifiedFilters = filters
+    ? `${filters} AND (content_type:"course" OR content_type:"program")`
+    : '(content_type:"course" OR content_type:"program")';
+
   return (
     <div
       data-testid={searchHeaderTestId}
@@ -55,7 +61,7 @@ const SearchHeader = ({
                 headerTitle={headerTitle}
                 hideTitle={hideTitle}
                 index={index}
-                filters={filters}
+                filters={modifiedFilters}
                 enterpriseSlug={slug}
                 suggestionSubmitOverride={suggestionSubmitOverride}
                 disableSuggestionRedirect={disableSuggestionRedirect}


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-10331

Update Algolia filter to only include programs and course content types in search suggestions because we are currently not supporting videos and pathways.

**Merge checklist:**
- [ ] Evaluate how your changes will impact existing consumers (e.g., `frontend-app-learner-portal-enterprise`, `frontend-app-admin-portal`, and `frontend-app-enterprise-public-catalog`). Will consumers safely be able to upgrade to this change without any breaking changes?
- [ ] Ensure your commit message follows the semantic-release conventional commit message format. If your changes include a breaking change, ensure your commit message is explicitly marked as a `BREAKING CHANGE` so the NPM package is released as such.
- [ ] Once CI is passing, verify the package versions that Lerna will increment to in the Github Action CI workflow logs.
    - *Note*: This may be found in the "Preview Updated Versions (dry run)" step in the Github Action CI workflow logs.

**Post merge:**
- [ ] Follow the [release steps in the README documentation](../README.rst#versioning-and-releases). Verify Lerna's release commit (e.g., ``chore(release): publish new versions``) that incremented versions in relevant package.json and CHANGELOG files, and created [Git tags](https://github.com/openedx/frontend-enterprise/tags) for those versions is on ``master`` (**Important: ensure the Git tags are for the correct commit SHA**).
- [ ] Run the ``Publish from package.json`` Github Action [workflow](https://github.com/openedx/frontend-enterprise/actions/workflows/publish-from-package.yml) to publish these new package versions to NPM.
    - This may be triggered by clicking the "Run workflow" option for the ``master`` branch.
- [ ] Verify the new package versions were published to NPM (i.e., ``npm view <package_name> versions --json``).
    - *Note*: There may be a slight delay between when the workflow finished and when NPM reports the package version as being published. If it doesn't appear right away in the above command, try again in a few minutes.
