### PR TITLE
chore: pin GitHub Actions workflows to full commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         # pulls all commits (needed for lerna / semantic release to correctly version)
         fetch-depth: 0
@@ -18,7 +18,7 @@ jobs:
     - name: Pull All Git Tags
       run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Setup Nodejs
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version-file: '.nvmrc'
     # lerna expects to be authenticated for publishing to NPM. This step will fail CI if NPM is not
@@ -43,4 +43,4 @@ jobs:
         git switch -c "actual-branch-not-detached-head"
         npx lerna@6 version --allow-branch actual-branch-not-detached-head --no-git-tag-version --no-changelog --no-push --yes
     - name: Coverage Report
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4

--- a/.github/workflows/publish-from-package.yml
+++ b/.github/workflows/publish-from-package.yml
@@ -8,16 +8,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           # pulls all commits (needed for lerna / semantic release to correctly version)
           fetch-depth: 0
       # pulls all tags (needed for lerna / semantic release to correctly version)
       - name: Pull All Git Tags
         run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-      - uses: fregante/setup-git-user@v1
+      - uses: fregante/setup-git-user@2e28d51939d2a84005a917d2f844090637f435f8 # v1.1.0
       - name: Setup Nodejs
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 16
       # lerna expects to be authenticated for publishing to NPM. This step will fail CI if NPM is not authenticated
@@ -35,7 +35,7 @@ jobs:
       - name: Build
         run: npm run build
       - name: Coverage Report
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
       - name: Publish to NPM from package.json versions
         run: npx lerna@6 publish from-package --yes
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,16 +8,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           # pulls all commits (needed for lerna / semantic release to correctly version)
           fetch-depth: 0
       # pulls all tags (needed for lerna / semantic release to correctly version)
       - name: Pull All Git Tags
         run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-      - uses: fregante/setup-git-user@v1
+      - uses: fregante/setup-git-user@2e28d51939d2a84005a917d2f844090637f435f8 # v1.1.0
       - name: Setup Nodejs
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
       # lerna expects to be authenticated for publishing to NPM. This step will fail CI if NPM is not authenticated
@@ -35,7 +35,7 @@ jobs:
       - name: Build
         run: npm run build
       - name: Coverage Report
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
       - name: Update automation/lerna/version branch
         run: |
           git switch -C automation/lerna/version
@@ -53,7 +53,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate Lerna Versions PR
         id: vpr
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # v4.2.4
         with:
             token: ${{ secrets.GITHUB_TOKEN }}
             title: "chore(release): publish :tada:"
@@ -63,7 +63,7 @@ jobs:
             base: master
       - name: Enable Lerna Versions PR Pull Request Automerge
         if: steps.vpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v2
+        uses: peter-evans/enable-pull-request-automerge@684fed02ccc9b5eefcf7d40b65b3cd44255bd5bc # v2.5.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           pull-request-number: ${{ steps.vpr.outputs.pull-request-number }}


### PR DESCRIPTION
Pins all `uses:` action refs to their full commit SHA with the version tag preserved as a comment. Part of org-wide SHA-pinning migration: openedx/.github#165